### PR TITLE
chore: clean api comments

### DIFF
--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,7 +1,4 @@
-// web/src/api.ts (replace entire file)
-
 import axios from "axios";
-// **FIXED**: Removed unused 'format' import
 import type { HistoryDay } from "./types";
 
 const api = axios.create({ baseURL: "http://localhost:8000/api" });


### PR DESCRIPTION
## Summary
- remove placeholder comments from API module
- retain only descriptive comments for API sections

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './config' is not defined)


------
https://chatgpt.com/codex/tasks/task_e_689642983b5c8327a700603b894a40e3