### PR TITLE
feat: track daily body weight

### DIFF
--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -102,3 +102,18 @@ export async function getHistory(startDate: string, endDate: string): Promise<Hi
   const response = await api.get("/history", { params });
   return response.data;
 }
+
+// --- Body Weight ---
+export async function getWeight(date: string) {
+  try {
+    const response = await api.get(`/weight/${date}`);
+    return response.data;
+  } catch (err) {
+    return null;
+  }
+}
+
+export async function setWeight(date: string, weight: number) {
+  const response = await api.put(`/weight/${date}`, { weight });
+  return response.data;
+}

--- a/web/src/components/Summary.tsx
+++ b/web/src/components/Summary.tsx
@@ -1,7 +1,15 @@
+import { useState, useEffect } from "react";
 import { useStore } from "../store";
 
 export function Summary() {
     const totals = useStore(state => state.day?.totals);
+    const weight = useStore(state => state.weight);
+    const saveWeight = useStore(state => state.saveWeight);
+    const [input, setInput] = useState("");
+
+    useEffect(() => {
+        setInput(weight != null ? weight.toString() : "");
+    }, [weight]);
 
     return (
         <div className="lg:col-span-1">
@@ -34,6 +42,13 @@ export function Summary() {
                             <b className="text-lg font-bold text-green-900 dark:text-green-100">{totals?.protein?.toFixed(1) || '0.0'}g</b>
                         </div>
 
+                    </div>
+                    <div className="mt-6">
+                        <label className="block mb-1 text-sm text-gray-700 dark:text-gray-300">Body Weight (lb)</label>
+                        <div className="flex gap-2">
+                            <input className="form-input flex-1" value={input} onChange={e => setInput(e.target.value)} />
+                            <button className="btn btn-primary" onClick={() => { const v = parseFloat(input); if(!isNaN(v)) saveWeight(v); }}>Save</button>
+                        </div>
                     </div>
                     <div className="text-xs text-gray-500 mt-4 text-center">Calories for custom foods use the label; USDA items use 4/4/9.</div>
                 </div>

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -70,6 +70,24 @@ export function DashboardPage() {
                     </ResponsiveContainer>
                 </div>
             </div>
+            <div className="card">
+                <div className="card-header"><h2 className="font-semibold text-lg dark:text-gray-200">Body Weight Trend (Last 7 Days)</h2></div>
+                <div className="card-body h-80">
+                    <ResponsiveContainer width="100%" height="100%">
+                        <LineChart data={formattedData}>
+                            <CartesianGrid strokeDasharray="3 3" stroke="rgba(128, 128, 128, 0.2)" />
+                            <XAxis dataKey="date" tick={{ fill: 'currentColor' }} />
+                            <YAxis tick={{ fill: 'currentColor' }} />
+                            <Tooltip
+                                contentStyle={{ backgroundColor: '#333', border: 'none' }}
+                                labelStyle={{ color: '#fff' }}
+                            />
+                            <Legend />
+                            <Line type="monotone" dataKey="weight" name="Weight" stroke="#8884d8" strokeWidth={2} activeDot={{ r: 8 }} />
+                        </LineChart>
+                    </ResponsiveContainer>
+                </div>
+            </div>
         </div>
     );
 }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -56,4 +56,5 @@ export type HistoryDay = {
     protein: number;
     fat: number;
     carb: number;
+    weight?: number;
 };


### PR DESCRIPTION
## Summary
- allow storing daily body weight with new API
- chart body weight trend on dashboard
- input body weight on tracker summary

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68964630e0b88327a3e965495a1e842b