### PR TITLE
feat: add daily macro goals

### DIFF
--- a/web/src/components/ControlPanel.tsx
+++ b/web/src/components/ControlPanel.tsx
@@ -23,13 +23,14 @@ type CustomFoodFormData = {
 };
 
 export function ControlPanel() {
-  const { date, mealName, allMyFoods, presets, setAllMyFoods, addFood, refreshPresets, applyPreset } = useStore();
+  const { date, mealName, allMyFoods, presets, setAllMyFoods, addFood, refreshPresets, applyPreset, goals, setGoals } = useStore();
   const currentMeal = useStore(state => state.day?.meals.find(m => m.name === state.mealName));
 
   const [isAddingFood, setIsAddingFood] = useState(false);
   const [isCreatingFood, setIsCreatingFood] = useState(false);
   const [isSavingPreset, setIsSavingPreset] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
+  const [goalInput, setGoalInput] = useState({ kcal: "", protein: "", fat: "", carb: "" });
 
   const { register, handleSubmit, formState: { errors, isValid }, watch, setValue, reset } = useForm<CustomFoodFormData>({
       mode: 'onChange',
@@ -76,6 +77,26 @@ export function ControlPanel() {
     });
     return copy;
   }
+
+  useEffect(() => {
+    setGoalInput({
+      kcal: goals.kcal ? goals.kcal.toString() : "",
+      protein: goals.protein ? goals.protein.toString() : "",
+      fat: goals.fat ? goals.fat.toString() : "",
+      carb: goals.carb ? goals.carb.toString() : "",
+    });
+  }, [goals]);
+
+  const handleSaveGoals = () => {
+    const g = {
+      kcal: parseFloat(goalInput.kcal) || 0,
+      protein: parseFloat(goalInput.protein) || 0,
+      fat: parseFloat(goalInput.fat) || 0,
+      carb: parseFloat(goalInput.carb) || 0,
+    };
+    setGoals(g);
+    toast.success('Goals saved!');
+  };
   
   async function doSearch() {
     if (!query.trim() || query.trim().length < 2) { setResults([]); return; }
@@ -317,6 +338,17 @@ export function ControlPanel() {
               </tbody>
             </table>
           </div>
+        </div>
+      </CollapsibleSection>
+      <CollapsibleSection title="Daily Goals" startOpen={true}>
+        <div className="space-y-2">
+          <div className="grid grid-cols-2 gap-2">
+            <input className="form-input" type="number" placeholder="kcal" value={goalInput.kcal} onChange={e=>setGoalInput({ ...goalInput, kcal: e.target.value })} />
+            <input className="form-input" type="number" step="0.1" placeholder="Protein g" value={goalInput.protein} onChange={e=>setGoalInput({ ...goalInput, protein: e.target.value })} />
+            <input className="form-input" type="number" step="0.1" placeholder="Fat g" value={goalInput.fat} onChange={e=>setGoalInput({ ...goalInput, fat: e.target.value })} />
+            <input className="form-input" type="number" step="0.1" placeholder="Carb g" value={goalInput.carb} onChange={e=>setGoalInput({ ...goalInput, carb: e.target.value })} />
+          </div>
+          <button className="btn btn-secondary w-full" onClick={handleSaveGoals}>Save Goals</button>
         </div>
       </CollapsibleSection>
       <CollapsibleSection title="Export Data">

--- a/web/src/components/Summary.tsx
+++ b/web/src/components/Summary.tsx
@@ -4,6 +4,7 @@ import { useStore } from "../store";
 export function Summary() {
     const totals = useStore(state => state.day?.totals);
     const weight = useStore(state => state.weight);
+    const goals = useStore(state => state.goals);
     const saveWeight = useStore(state => state.saveWeight);
     const [input, setInput] = useState("");
 
@@ -19,27 +20,61 @@ export function Summary() {
                     {/* --- KEY CHANGES HERE --- */}
                     {/* Changed from grid to flex for better responsive scaling */}
                     <div className="flex justify-between items-stretch gap-2">
-                        
-                        {/* flex-1 allows each card to take up equal space */}
+
+                        {/* kcal */}
                         <div className="flex-1 bg-indigo-50 dark:bg-indigo-900/50 p-3 rounded-lg text-center transition-shadow hover:shadow-md">
                             <div className="text-sm text-indigo-800 dark:text-indigo-200">kcal</div>
-                            {/* Reduced font size slightly to prevent wrapping */}
-                            <b className="text-lg font-bold text-indigo-900 dark:text-indigo-100">{totals?.kcal?.toFixed(0) || '0'}</b>
+                            <b className="text-lg font-bold text-indigo-900 dark:text-indigo-100">{(totals?.kcal ?? 0).toFixed(0)}</b>
+                            {goals.kcal > 0 && (
+                                <>
+                                    <div className="mt-1 text-xs text-indigo-700 dark:text-indigo-300">{(totals?.kcal ?? 0).toFixed(0)} / {goals.kcal}</div>
+                                    <div className="w-full bg-indigo-200 rounded h-2 mt-1">
+                                        <div className="h-2 rounded bg-indigo-500" style={{ width: `${Math.min(100, ((totals?.kcal ?? 0) / goals.kcal) * 100)}%` }}></div>
+                                    </div>
+                                </>
+                            )}
                         </div>
 
+                        {/* fat */}
                         <div className="flex-1 bg-yellow-50 dark:bg-yellow-900/50 p-3 rounded-lg text-center transition-shadow hover:shadow-md">
                             <div className="text-sm text-yellow-800 dark:text-yellow-200">Fat</div>
-                            <b className="text-lg font-bold text-yellow-900 dark:text-yellow-100">{totals?.fat?.toFixed(1) || '0.0'}g</b>
+                            <b className="text-lg font-bold text-yellow-900 dark:text-yellow-100">{(totals?.fat ?? 0).toFixed(1)}g</b>
+                            {goals.fat > 0 && (
+                                <>
+                                    <div className="mt-1 text-xs text-yellow-700 dark:text-yellow-300">{(totals?.fat ?? 0).toFixed(1)} / {goals.fat}g</div>
+                                    <div className="w-full bg-yellow-200 rounded h-2 mt-1">
+                                        <div className="h-2 rounded bg-yellow-500" style={{ width: `${Math.min(100, ((totals?.fat ?? 0) / goals.fat) * 100)}%` }}></div>
+                                    </div>
+                                </>
+                            )}
                         </div>
 
+                        {/* carb */}
                         <div className="flex-1 bg-red-50 dark:bg-red-900/50 p-3 rounded-lg text-center transition-shadow hover:shadow-md">
                             <div className="text-sm text-red-800 dark:text-red-200">Carb</div>
-                            <b className="text-lg font-bold text-red-900 dark:text-red-100">{totals?.carb?.toFixed(1) || '0.0'}g</b>
+                            <b className="text-lg font-bold text-red-900 dark:text-red-100">{(totals?.carb ?? 0).toFixed(1)}g</b>
+                            {goals.carb > 0 && (
+                                <>
+                                    <div className="mt-1 text-xs text-red-700 dark:text-red-300">{(totals?.carb ?? 0).toFixed(1)} / {goals.carb}g</div>
+                                    <div className="w-full bg-red-200 rounded h-2 mt-1">
+                                        <div className="h-2 rounded bg-red-500" style={{ width: `${Math.min(100, ((totals?.carb ?? 0) / goals.carb) * 100)}%` }}></div>
+                                    </div>
+                                </>
+                            )}
                         </div>
-                        
+
+                        {/* protein */}
                         <div className="flex-1 bg-green-50 dark:bg-green-900/50 p-3 rounded-lg text-center transition-shadow hover:shadow-md">
                             <div className="text-sm text-green-800 dark:text-green-200">Protein</div>
-                            <b className="text-lg font-bold text-green-900 dark:text-green-100">{totals?.protein?.toFixed(1) || '0.0'}g</b>
+                            <b className="text-lg font-bold text-green-900 dark:text-green-100">{(totals?.protein ?? 0).toFixed(1)}g</b>
+                            {goals.protein > 0 && (
+                                <>
+                                    <div className="mt-1 text-xs text-green-700 dark:text-green-300">{(totals?.protein ?? 0).toFixed(1)} / {goals.protein}g</div>
+                                    <div className="w-full bg-green-200 rounded h-2 mt-1">
+                                        <div className="h-2 rounded bg-green-500" style={{ width: `${Math.min(100, ((totals?.protein ?? 0) / goals.protein) * 100)}%` }}></div>
+                                    </div>
+                                </>
+                            )}
                         </div>
 
                     </div>

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
 import './index.css'

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import toast from 'react-hot-toast';
 import * as api from './api';
-import type { DayFull, Preset, SimpleFood, MealType } from "./types";
+import type { DayFull, Preset, SimpleFood, MealType, Goals } from "./types";
 
 type Theme = 'light' | 'dark';
 
@@ -15,6 +15,7 @@ interface AppState {
   allMyFoods: SimpleFood[];
   presets: Preset[];
   weight: number | null;
+  goals: Goals;
 }
 
 interface AppActions {
@@ -34,6 +35,7 @@ interface AppActions {
   applyPreset: (presetId: number) => Promise<void>;
   setAllMyFoods: (foods: SimpleFood[]) => void;
   saveWeight: (w: number) => Promise<void>;
+  setGoals: (g: Goals) => void;
 }
 
 const getInitialTheme = (): Theme => {
@@ -45,6 +47,16 @@ const getInitialTheme = (): Theme => {
     return 'light';
 };
 
+const getInitialGoals = (): Goals => {
+  if (typeof window !== 'undefined') {
+    try {
+      const raw = localStorage.getItem('goals');
+      if (raw) return JSON.parse(raw);
+    } catch { /* ignore */ }
+  }
+  return { kcal: 0, protein: 0, fat: 0, carb: 0 };
+};
+
 export const useStore = create<AppState & AppActions>((set, get) => ({
   copiedMealId: null,
   theme: getInitialTheme(),
@@ -54,6 +66,7 @@ export const useStore = create<AppState & AppActions>((set, get) => ({
   allMyFoods: [],
   presets: [],
   weight: null,
+  goals: getInitialGoals(),
 
   copyMeal: (mealId: number) => {
     set({ copiedMealId: mealId });
@@ -170,5 +183,12 @@ export const useStore = create<AppState & AppActions>((set, get) => ({
     } catch (e: any) {
       toast.error(e?.response?.data?.detail || "Failed to apply preset.");
     }
+  },
+
+  setGoals: (g) => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('goals', JSON.stringify(g));
+    }
+    set({ goals: g });
   }
 }));

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -58,3 +58,11 @@ export type HistoryDay = {
     carb: number;
     weight?: number;
 };
+
+// User-configurable daily macro goals
+export type Goals = {
+  kcal: number;
+  protein: number;
+  fat: number;
+  carb: number;
+};


### PR DESCRIPTION
## Summary
- allow users to save daily calorie and macro goals in local storage
- add Daily Goals section in control panel for editing targets
- show progress toward goals in Today's Totals card with progress bars

## Testing
- `npm run lint` *(fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './config' is not defined by "exports" in eslint/package.json)*
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68964aecfa548327a5f12c5948724b1c