### PR TITLE
Add flexible date range filters to dashboard charts

### DIFF
--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -6,13 +6,13 @@ import type { HistoryDay } from "../types";
 
 export function DashboardPage() {
     const [data, setData] = useState<HistoryDay[]>([]);
-    // <-- Removed the `loading` state
+    const [days, setDays] = useState(7);
 
     useEffect(() => {
         const fetchHistory = async () => {
             try {
                 const endDate = new Date();
-                const startDate = subDays(endDate, 6);
+                const startDate = subDays(endDate, days - 1);
                 const historyData = await getHistory(
                     format(startDate, 'yyyy-MM-dd'),
                     format(endDate, 'yyyy-MM-dd')
@@ -20,28 +20,36 @@ export function DashboardPage() {
                 setData(historyData);
             } catch (error) {
                 console.error("Failed to fetch history:", error);
-            } 
-            // <-- Removed the `finally` block and setLoading(false)
+            }
         };
         fetchHistory();
-    }, []);
+    }, [days]);
 
-    // <-- Removed the conditional "if (loading) { ... }" block
-
-    const formattedData = data.map(d => ({...d, date: format(parseISO(d.date), 'E dd')}));
+    const formattedData = data.map(d => ({ ...d, date: format(parseISO(d.date), days > 7 ? 'MMM dd' : 'E dd') }));
 
     return (
         <div className="space-y-8">
+            <div className="flex gap-2">
+                {[7, 30, 90].map(opt => (
+                    <button
+                        key={opt}
+                        onClick={() => setDays(opt)}
+                        className={`px-3 py-1 rounded ${days === opt ? 'bg-blue-500 text-white' : 'bg-gray-200 dark:bg-gray-700'}`}
+                    >
+                        Last {opt} Days
+                    </button>
+                ))}
+            </div>
             <div className="card">
-                <div className="card-header"><h2 className="font-semibold text-lg dark:text-gray-200">Calorie Trend (Last 7 Days)</h2></div>
+                <div className="card-header"><h2 className="font-semibold text-lg dark:text-gray-200">Calorie Trend (Last {days} Days)</h2></div>
                 <div className="card-body h-80">
                     <ResponsiveContainer width="100%" height="100%">
                         <LineChart data={formattedData}>
                             <CartesianGrid strokeDasharray="3 3" stroke="rgba(128, 128, 128, 0.2)" />
                             <XAxis dataKey="date" tick={{ fill: 'currentColor' }} />
                             <YAxis tick={{ fill: 'currentColor' }} />
-                            <Tooltip 
-                                contentStyle={{ backgroundColor: '#333', border: 'none' }} 
+                            <Tooltip
+                                contentStyle={{ backgroundColor: '#333', border: 'none' }}
                                 labelStyle={{ color: '#fff' }}
                             />
                             <Legend />
@@ -51,15 +59,15 @@ export function DashboardPage() {
                 </div>
             </div>
             <div className="card">
-                <div className="card-header"><h2 className="font-semibold text-lg dark:text-gray-200">Macro Trend (Last 7 Days)</h2></div>
+                <div className="card-header"><h2 className="font-semibold text-lg dark:text-gray-200">Macro Trend (Last {days} Days)</h2></div>
                 <div className="card-body h-80">
                     <ResponsiveContainer width="100%" height="100%">
                         <LineChart data={formattedData}>
                             <CartesianGrid strokeDasharray="3 3" stroke="rgba(128, 128, 128, 0.2)" />
                             <XAxis dataKey="date" tick={{ fill: 'currentColor' }} />
                             <YAxis tick={{ fill: 'currentColor' }} />
-                            <Tooltip 
-                                contentStyle={{ backgroundColor: '#333', border: 'none' }} 
+                            <Tooltip
+                                contentStyle={{ backgroundColor: '#333', border: 'none' }}
                                 labelStyle={{ color: '#fff' }}
                             />
                             <Legend />
@@ -71,7 +79,7 @@ export function DashboardPage() {
                 </div>
             </div>
             <div className="card">
-                <div className="card-header"><h2 className="font-semibold text-lg dark:text-gray-200">Body Weight Trend (Last 7 Days)</h2></div>
+                <div className="card-header"><h2 className="font-semibold text-lg dark:text-gray-200">Body Weight Trend (Last {days} Days)</h2></div>
                 <div className="card-body h-80">
                     <ResponsiveContainer width="100%" height="100%">
                         <LineChart data={formattedData}>


### PR DESCRIPTION
## Summary
- Add 7/30/90 day range selector to dashboard
- Fetch historical data based on selected range and adjust chart titles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Package subpath './config' is not defined by "exports" in eslint)
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689798aeb718832792ca32ec69687cd4