### PR TITLE
feat: add chart loading spinner

### DIFF
--- a/web/src/components/LoadingSpinner.tsx
+++ b/web/src/components/LoadingSpinner.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export function LoadingSpinner() {
+    return (
+        <div className="flex h-full items-center justify-center">
+            <div className="h-12 w-12 animate-spin rounded-full border-4 border-gray-300 border-t-blue-500"></div>
+        </div>
+    );
+}

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -3,13 +3,16 @@ import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, Responsi
 import { format, subDays, parseISO } from 'date-fns';
 import { getHistory } from "../api";
 import type { HistoryDay } from "../types";
+import { LoadingSpinner } from "../components/LoadingSpinner";
 
 export function DashboardPage() {
     const [data, setData] = useState<HistoryDay[]>([]);
     const [days, setDays] = useState(7);
+    const [loading, setLoading] = useState(true);
 
     useEffect(() => {
         const fetchHistory = async () => {
+            setLoading(true);
             try {
                 const endDate = new Date();
                 const startDate = subDays(endDate, days - 1);
@@ -20,6 +23,8 @@ export function DashboardPage() {
                 setData(historyData);
             } catch (error) {
                 console.error("Failed to fetch history:", error);
+            } finally {
+                setLoading(false);
             }
         };
         fetchHistory();
@@ -43,57 +48,69 @@ export function DashboardPage() {
             <div className="card">
                 <div className="card-header"><h2 className="font-semibold text-lg dark:text-gray-200">Calorie Trend (Last {days} Days)</h2></div>
                 <div className="card-body h-80">
-                    <ResponsiveContainer width="100%" height="100%">
-                        <LineChart data={formattedData}>
-                            <CartesianGrid strokeDasharray="3 3" stroke="rgba(128, 128, 128, 0.2)" />
-                            <XAxis dataKey="date" tick={{ fill: 'currentColor' }} />
-                            <YAxis tick={{ fill: 'currentColor' }} />
-                            <Tooltip
-                                contentStyle={{ backgroundColor: '#333', border: 'none' }}
-                                labelStyle={{ color: '#fff' }}
-                            />
-                            <Legend />
-                            <Line type="monotone" dataKey="kcal" stroke="#8884d8" strokeWidth={2} activeDot={{ r: 8 }} />
-                        </LineChart>
-                    </ResponsiveContainer>
+                    {loading ? (
+                        <LoadingSpinner />
+                    ) : (
+                        <ResponsiveContainer width="100%" height="100%">
+                            <LineChart data={formattedData}>
+                                <CartesianGrid strokeDasharray="3 3" stroke="rgba(128, 128, 128, 0.2)" />
+                                <XAxis dataKey="date" tick={{ fill: 'currentColor' }} />
+                                <YAxis tick={{ fill: 'currentColor' }} />
+                                <Tooltip
+                                    contentStyle={{ backgroundColor: '#333', border: 'none' }}
+                                    labelStyle={{ color: '#fff' }}
+                                />
+                                <Legend />
+                                <Line type="monotone" dataKey="kcal" stroke="#8884d8" strokeWidth={2} activeDot={{ r: 8 }} />
+                            </LineChart>
+                        </ResponsiveContainer>
+                    )}
                 </div>
             </div>
             <div className="card">
                 <div className="card-header"><h2 className="font-semibold text-lg dark:text-gray-200">Macro Trend (Last {days} Days)</h2></div>
                 <div className="card-body h-80">
-                    <ResponsiveContainer width="100%" height="100%">
-                        <LineChart data={formattedData}>
-                            <CartesianGrid strokeDasharray="3 3" stroke="rgba(128, 128, 128, 0.2)" />
-                            <XAxis dataKey="date" tick={{ fill: 'currentColor' }} />
-                            <YAxis tick={{ fill: 'currentColor' }} />
-                            <Tooltip
-                                contentStyle={{ backgroundColor: '#333', border: 'none' }}
-                                labelStyle={{ color: '#fff' }}
-                            />
-                            <Legend />
-                            <Line type="monotone" dataKey="protein" name="Protein (g)" stroke="#82ca9d" strokeWidth={2} activeDot={{ r: 8 }} />
-                            <Line type="monotone" dataKey="fat" name="Fat (g)" stroke="#ffc658" strokeWidth={2} activeDot={{ r: 8 }} />
-                            <Line type="monotone" dataKey="carb" name="Carbs (g)" stroke="#ff8042" strokeWidth={2} activeDot={{ r: 8 }} />
-                        </LineChart>
-                    </ResponsiveContainer>
+                    {loading ? (
+                        <LoadingSpinner />
+                    ) : (
+                        <ResponsiveContainer width="100%" height="100%">
+                            <LineChart data={formattedData}>
+                                <CartesianGrid strokeDasharray="3 3" stroke="rgba(128, 128, 128, 0.2)" />
+                                <XAxis dataKey="date" tick={{ fill: 'currentColor' }} />
+                                <YAxis tick={{ fill: 'currentColor' }} />
+                                <Tooltip
+                                    contentStyle={{ backgroundColor: '#333', border: 'none' }}
+                                    labelStyle={{ color: '#fff' }}
+                                />
+                                <Legend />
+                                <Line type="monotone" dataKey="protein" name="Protein (g)" stroke="#82ca9d" strokeWidth={2} activeDot={{ r: 8 }} />
+                                <Line type="monotone" dataKey="fat" name="Fat (g)" stroke="#ffc658" strokeWidth={2} activeDot={{ r: 8 }} />
+                                <Line type="monotone" dataKey="carb" name="Carbs (g)" stroke="#ff8042" strokeWidth={2} activeDot={{ r: 8 }} />
+                            </LineChart>
+                        </ResponsiveContainer>
+                    )}
                 </div>
             </div>
             <div className="card">
                 <div className="card-header"><h2 className="font-semibold text-lg dark:text-gray-200">Body Weight Trend (Last {days} Days)</h2></div>
                 <div className="card-body h-80">
-                    <ResponsiveContainer width="100%" height="100%">
-                        <LineChart data={formattedData}>
-                            <CartesianGrid strokeDasharray="3 3" stroke="rgba(128, 128, 128, 0.2)" />
-                            <XAxis dataKey="date" tick={{ fill: 'currentColor' }} />
-                            <YAxis tick={{ fill: 'currentColor' }} />
-                            <Tooltip
-                                contentStyle={{ backgroundColor: '#333', border: 'none' }}
-                                labelStyle={{ color: '#fff' }}
-                            />
-                            <Legend />
-                            <Line type="monotone" dataKey="weight" name="Weight" stroke="#8884d8" strokeWidth={2} activeDot={{ r: 8 }} />
-                        </LineChart>
-                    </ResponsiveContainer>
+                    {loading ? (
+                        <LoadingSpinner />
+                    ) : (
+                        <ResponsiveContainer width="100%" height="100%">
+                            <LineChart data={formattedData}>
+                                <CartesianGrid strokeDasharray="3 3" stroke="rgba(128, 128, 128, 0.2)" />
+                                <XAxis dataKey="date" tick={{ fill: 'currentColor' }} />
+                                <YAxis tick={{ fill: 'currentColor' }} />
+                                <Tooltip
+                                    contentStyle={{ backgroundColor: '#333', border: 'none' }}
+                                    labelStyle={{ color: '#fff' }}
+                                />
+                                <Legend />
+                                <Line type="monotone" dataKey="weight" name="Weight" stroke="#8884d8" strokeWidth={2} activeDot={{ r: 8 }} />
+                            </LineChart>
+                        </ResponsiveContainer>
+                    )}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- show animated loading indicator while dashboard chart data loads
- centralize spinner UI in reusable `LoadingSpinner` component

## Testing
- `pytest`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Package subpath './config' is not defined by "exports")*

------
https://chatgpt.com/codex/tasks/task_e_6898ee15bba08327b1e080346f3f8b2a