### PR TITLE
Add radial gauge for daily totals

### DIFF
--- a/web/src/components/RadialProgress.tsx
+++ b/web/src/components/RadialProgress.tsx
@@ -1,0 +1,55 @@
+interface RadialProgressProps {
+    value: number;
+    goal: number;
+    color: string; // tailwind color class for stroke
+    decimals?: number;
+    unit?: string;
+}
+
+export function RadialProgress({ value, goal, color, decimals = 0, unit = "" }: RadialProgressProps) {
+    const pct = goal > 0 ? Math.min(100, (value / goal) * 100) : 0;
+    const radius = 28;
+    const circumference = 2 * Math.PI * radius;
+    const offset = circumference - (pct / 100) * circumference;
+
+    return (
+        <div className="flex flex-col items-center">
+            <div className="relative w-20 h-20">
+                <svg className="w-20 h-20" viewBox="0 0 64 64">
+                    <circle
+                        className="text-gray-200 dark:text-gray-700"
+                        strokeWidth="4"
+                        stroke="currentColor"
+                        fill="transparent"
+                        r={radius}
+                        cx="32"
+                        cy="32"
+                    />
+                    <circle
+                        className={`${color} stroke-current`}
+                        strokeWidth="4"
+                        strokeLinecap="round"
+                        stroke="currentColor"
+                        fill="transparent"
+                        r={radius}
+                        cx="32"
+                        cy="32"
+                        strokeDasharray={circumference}
+                        strokeDashoffset={offset}
+                        transform="rotate(-90 32 32)"
+                    />
+                </svg>
+                <div className="absolute inset-0 flex items-center justify-center text-sm font-bold text-gray-900 dark:text-gray-100">
+                    {value.toFixed(decimals)}{unit}
+                </div>
+            </div>
+            {goal > 0 && (
+                <div className="text-xs mt-1 text-gray-700 dark:text-gray-300">
+                    {value.toFixed(decimals)}{unit} / {goal}{unit}
+                </div>
+            )}
+        </div>
+    );
+}
+
+export default RadialProgress;

--- a/web/src/components/Summary.tsx
+++ b/web/src/components/Summary.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { useStore } from "../store";
+import RadialProgress from "./RadialProgress";
 
 export function Summary() {
     const totals = useStore(state => state.day?.totals);
@@ -17,66 +18,30 @@ export function Summary() {
             <div className="sticky top-6 card">
                 <div className="card-header"><h2 className="font-semibold text-lg dark:text-gray-200">Today's Totals</h2></div>
                 <div className="card-body">
-                    {/* --- KEY CHANGES HERE --- */}
-                    {/* Changed from grid to flex for better responsive scaling */}
                     <div className="flex justify-between items-stretch gap-2">
-
                         {/* kcal */}
                         <div className="flex-1 bg-indigo-50 dark:bg-indigo-900/50 p-3 rounded-lg text-center transition-shadow hover:shadow-md">
-                            <div className="text-sm text-indigo-800 dark:text-indigo-200">kcal</div>
-                            <b className="text-lg font-bold text-indigo-900 dark:text-indigo-100">{(totals?.kcal ?? 0).toFixed(0)}</b>
-                            {goals.kcal > 0 && (
-                                <>
-                                    <div className="mt-1 text-xs text-indigo-700 dark:text-indigo-300">{(totals?.kcal ?? 0).toFixed(0)} / {goals.kcal}</div>
-                                    <div className="w-full bg-indigo-200 rounded h-2 mt-1">
-                                        <div className="h-2 rounded bg-indigo-500" style={{ width: `${Math.min(100, ((totals?.kcal ?? 0) / goals.kcal) * 100)}%` }}></div>
-                                    </div>
-                                </>
-                            )}
+                            <div className="text-sm text-indigo-800 dark:text-indigo-200 mb-2">kcal</div>
+                            <RadialProgress value={totals?.kcal ?? 0} goal={goals.kcal} color="text-indigo-500" decimals={0} />
                         </div>
 
                         {/* fat */}
                         <div className="flex-1 bg-yellow-50 dark:bg-yellow-900/50 p-3 rounded-lg text-center transition-shadow hover:shadow-md">
-                            <div className="text-sm text-yellow-800 dark:text-yellow-200">Fat</div>
-                            <b className="text-lg font-bold text-yellow-900 dark:text-yellow-100">{(totals?.fat ?? 0).toFixed(1)}g</b>
-                            {goals.fat > 0 && (
-                                <>
-                                    <div className="mt-1 text-xs text-yellow-700 dark:text-yellow-300">{(totals?.fat ?? 0).toFixed(1)} / {goals.fat}g</div>
-                                    <div className="w-full bg-yellow-200 rounded h-2 mt-1">
-                                        <div className="h-2 rounded bg-yellow-500" style={{ width: `${Math.min(100, ((totals?.fat ?? 0) / goals.fat) * 100)}%` }}></div>
-                                    </div>
-                                </>
-                            )}
+                            <div className="text-sm text-yellow-800 dark:text-yellow-200 mb-2">Fat</div>
+                            <RadialProgress value={totals?.fat ?? 0} goal={goals.fat} color="text-yellow-500" decimals={1} unit="g" />
                         </div>
 
                         {/* carb */}
                         <div className="flex-1 bg-red-50 dark:bg-red-900/50 p-3 rounded-lg text-center transition-shadow hover:shadow-md">
-                            <div className="text-sm text-red-800 dark:text-red-200">Carb</div>
-                            <b className="text-lg font-bold text-red-900 dark:text-red-100">{(totals?.carb ?? 0).toFixed(1)}g</b>
-                            {goals.carb > 0 && (
-                                <>
-                                    <div className="mt-1 text-xs text-red-700 dark:text-red-300">{(totals?.carb ?? 0).toFixed(1)} / {goals.carb}g</div>
-                                    <div className="w-full bg-red-200 rounded h-2 mt-1">
-                                        <div className="h-2 rounded bg-red-500" style={{ width: `${Math.min(100, ((totals?.carb ?? 0) / goals.carb) * 100)}%` }}></div>
-                                    </div>
-                                </>
-                            )}
+                            <div className="text-sm text-red-800 dark:text-red-200 mb-2">Carb</div>
+                            <RadialProgress value={totals?.carb ?? 0} goal={goals.carb} color="text-red-500" decimals={1} unit="g" />
                         </div>
 
                         {/* protein */}
                         <div className="flex-1 bg-green-50 dark:bg-green-900/50 p-3 rounded-lg text-center transition-shadow hover:shadow-md">
-                            <div className="text-sm text-green-800 dark:text-green-200">Protein</div>
-                            <b className="text-lg font-bold text-green-900 dark:text-green-100">{(totals?.protein ?? 0).toFixed(1)}g</b>
-                            {goals.protein > 0 && (
-                                <>
-                                    <div className="mt-1 text-xs text-green-700 dark:text-green-300">{(totals?.protein ?? 0).toFixed(1)} / {goals.protein}g</div>
-                                    <div className="w-full bg-green-200 rounded h-2 mt-1">
-                                        <div className="h-2 rounded bg-green-500" style={{ width: `${Math.min(100, ((totals?.protein ?? 0) / goals.protein) * 100)}%` }}></div>
-                                    </div>
-                                </>
-                            )}
+                            <div className="text-sm text-green-800 dark:text-green-200 mb-2">Protein</div>
+                            <RadialProgress value={totals?.protein ?? 0} goal={goals.protein} color="text-green-500" decimals={1} unit="g" />
                         </div>
-
                     </div>
                     <div className="mt-6">
                         <label className="block mb-1 text-sm text-gray-700 dark:text-gray-300">Body Weight (lb)</label>


### PR DESCRIPTION
## Summary
- replace linear progress bars with radial gauges for calories and macros
- add reusable RadialProgress component for circular progress display

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Package subpath './config' is not defined by "exports" in eslint)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898ee30af0c8327b9c076542d454007