### PR TITLE
feat: expand app to full width

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -24,7 +24,7 @@ export default function App() {
 
   return (
     <BrowserRouter>
-      <div className="p-4 lg:p-6 max-w-screen-2xl mx-auto bg-gray-100 dark:bg-gray-900 min-h-screen font-sans">
+      <div className="p-4 lg:p-6 w-full bg-gray-100 dark:bg-gray-900 min-h-screen font-sans">
         <Toaster position="bottom-center" toastOptions={{ style: { background: '#363636', color: '#fff' }, success: { duration: 3000 } }}/>
         
         <header className="relative mb-6 flex items-center justify-between">


### PR DESCRIPTION
## Summary
- expand root layout container to span full viewport width

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Package subpath './config' is not defined by "exports" in eslint)
- `npm run build` (fails: src/components/LoadingSpinner.tsx(1,1): error TS6133: 'React' is declared but its value is never read.)

------
https://chatgpt.com/codex/tasks/task_e_6898f25f62208327ae63ea8c5d0584e1