### PR TITLE
feat: keep navigation visible while scrolling

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -27,7 +27,7 @@ export default function App() {
       <div className="p-4 lg:p-6 w-full bg-gray-100 dark:bg-gray-900 min-h-screen font-sans">
         <Toaster position="bottom-center" toastOptions={{ style: { background: '#363636', color: '#fff' }, success: { duration: 3000 } }}/>
         
-        <header className="relative mb-6 flex items-center justify-between">
+        <header className="sticky top-0 z-10 mb-6 flex items-center justify-between bg-gray-100 dark:bg-gray-900">
             <nav className="flex items-center gap-4">
                 <h1 className="text-xl lg:text-3xl font-bold text-gray-800 dark:text-gray-100 mr-4">Macro Tracker</h1>
                 <NavLink to="/" className={navLinkClass}>Tracker</NavLink>

--- a/web/src/components/LoadingSpinner.tsx
+++ b/web/src/components/LoadingSpinner.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 export function LoadingSpinner() {
     return (
         <div className="flex h-full items-center justify-center">


### PR DESCRIPTION
## Summary
- keep header and navigation visible while scrolling with a sticky layout
- remove unused React import from LoadingSpinner component

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED])
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898f82145ac83278bff37bc6d768ed7