### PR TITLE
fix: resolve heroicons imports

### DIFF
--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -6,6 +6,9 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "paths": {
+      "@heroicons/react/*": ["./node_modules/@heroicons/react/*"]
+    },
 
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Summary
- map `@heroicons/react` subpath imports so TypeScript resolves icon modules

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898ff1a609483279a86c5d395be97ce