### PR TITLE
Improve desktop layout spacing

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -35,7 +35,7 @@ export default function App() {
         <Toaster position="bottom-center" toastOptions={{ style: { background: '#363636', color: '#fff' }, success: { duration: 3000 } }} />
 
         <header className="sticky top-0 z-10 bg-gray-100 dark:bg-gray-900">
-          <div className="max-w-screen-xl mx-auto flex items-center justify-between px-4 py-4 lg:px-6">
+          <div className="mx-auto flex items-center justify-between px-4 py-4 lg:px-6">
             <div className="flex items-center gap-2">
               <button className="lg:hidden text-gray-800 dark:text-gray-100" onClick={() => setMenuOpen(true)}>
                 <Bars3Icon className="h-6 w-6" />
@@ -73,7 +73,7 @@ export default function App() {
           </div>
         </div>
 
-        <main className="max-w-screen-xl mx-auto px-4 py-6 lg:px-6">
+        <main className="mx-auto px-4 py-6 lg:px-6">
           <Routes>
             <Route path="/" element={<TrackerPage />} />
             <Route path="/dashboard" element={<DashboardPage />} />

--- a/web/src/components/ControlPanel.tsx
+++ b/web/src/components/ControlPanel.tsx
@@ -220,7 +220,7 @@ export function ControlPanel() {
   }
 
   return (
-    <div className="lg:col-span-1">
+    <div>
       <div className="card">
         <div className="card-header p-0">
           <div className="flex">

--- a/web/src/components/DailyLog.tsx
+++ b/web/src/components/DailyLog.tsx
@@ -40,7 +40,7 @@ export function DailyLog() {
   }, [day]);
 
   return (
-    <div className="lg:col-span-2 space-y-6">
+    <div className="space-y-6">
       <div className="card">
         <div className="card-body flex flex-wrap items-center justify-between gap-4">
           <div className="flex items-center gap-2">

--- a/web/src/components/Summary.tsx
+++ b/web/src/components/Summary.tsx
@@ -14,7 +14,7 @@ export function Summary() {
     }, [weight]);
 
     return (
-        <div className="lg:col-span-1">
+        <div>
             <div className="sticky top-6 card">
                 <div className="card-header"><h2 className="font-semibold text-lg dark:text-gray-200">Today's Totals</h2></div>
                 <div className="card-body">

--- a/web/src/pages/TrackerPage.tsx
+++ b/web/src/pages/TrackerPage.tsx
@@ -1,12 +1,10 @@
-// web/src/pages/TrackerPage.tsx (New File)
-
 import { ControlPanel } from "../components/ControlPanel";
 import { DailyLog } from "../components/DailyLog";
 import { Summary } from "../components/Summary";
 
 export function TrackerPage() {
     return (
-        <div className="grid grid-cols-1 lg:grid-cols-4 gap-8">
+        <div className="grid grid-cols-1 lg:grid-cols-[1fr_3fr_1fr] gap-8">
             <ControlPanel />
             <DailyLog />
             <Summary />


### PR DESCRIPTION
## Summary
- remove fixed max-width wrapper so desktop layout can expand
- simplify tracker grid with responsive 1fr/3fr/1fr columns
- drop internal column span classes from tracker components

## Testing
- `npm run lint` *(fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED])*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899052143d48327aef265537f3a4995