### PR TITLE
feat(web): add brand colors and font

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,6 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Macro Tracker</title>
   </head>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -20,8 +20,8 @@ export default function App() {
   const navLinkClass = ({ isActive }: { isActive: boolean }) =>
     `flex items-center gap-2 px-4 py-2 rounded-md text-sm font-semibold transition-colors ${
       isActive
-        ? 'bg-indigo-600 text-white'
-        : 'text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700'
+        ? 'bg-brand-primary text-text-light'
+        : 'text-text dark:text-text-light hover:bg-surface-light dark:hover:bg-border-dark'
     }`;
 
   const navItems = [
@@ -31,16 +31,16 @@ export default function App() {
 
   return (
     <BrowserRouter>
-      <div className="min-h-screen bg-gray-100 dark:bg-gray-900 font-sans">
+      <div className="min-h-screen bg-surface-light dark:bg-surface-dark font-sans">
         <Toaster position="bottom-center" toastOptions={{ style: { background: '#363636', color: '#fff' }, success: { duration: 3000 } }} />
 
-        <header className="sticky top-0 z-10 bg-gray-100 dark:bg-gray-900">
+        <header className="sticky top-0 z-10 bg-surface-light dark:bg-surface-dark">
           <div className="mx-auto flex items-center justify-between px-4 py-4 lg:px-6">
             <div className="flex items-center gap-2">
-              <button className="lg:hidden text-gray-800 dark:text-gray-100" onClick={() => setMenuOpen(true)}>
+              <button className="lg:hidden text-text dark:text-text-light" onClick={() => setMenuOpen(true)}>
                 <Bars3Icon className="h-6 w-6" />
               </button>
-              <h1 className="text-xl lg:text-3xl font-bold text-gray-800 dark:text-gray-100">Macro Tracker</h1>
+              <h1 className="text-xl lg:text-3xl font-bold text-text dark:text-text-light">Macro Tracker</h1>
             </div>
             <div className="flex items-center gap-4">
               <nav className="hidden lg:flex items-center gap-4">
@@ -58,8 +58,8 @@ export default function App() {
 
         <div className={`fixed inset-0 z-20 transform transition-transform duration-200 lg:hidden ${menuOpen ? 'translate-x-0' : '-translate-x-full'}`}>
           <div className="absolute inset-0 bg-black/50" onClick={() => setMenuOpen(false)}></div>
-          <div className="relative bg-gray-100 dark:bg-gray-900 w-64 h-full p-4">
-            <button className="mb-4 text-gray-800 dark:text-gray-100" onClick={() => setMenuOpen(false)}>
+          <div className="relative bg-surface-light dark:bg-surface-dark w-64 h-full p-4">
+            <button className="mb-4 text-text dark:text-text-light" onClick={() => setMenuOpen(false)}>
               <XMarkIcon className="h-6 w-6" />
             </button>
             <nav className="flex flex-col gap-2">

--- a/web/src/components/ControlPanel.tsx
+++ b/web/src/components/ControlPanel.tsx
@@ -230,8 +230,8 @@ export function ControlPanel() {
                 onClick={() => setTab(t.key)}
                 className={`flex-1 px-3 py-2 text-sm font-medium border-b-2 ${
                   tab === t.key
-                    ? 'border-indigo-600 text-indigo-600'
-                    : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'
+                    ? 'border-brand-primary text-brand-primary'
+                    : 'border-transparent text-text-muted hover:text-text dark:hover:text-text-light'
                 }`}
               >
                 {t.label}
@@ -253,34 +253,34 @@ export function ControlPanel() {
                   {DATA_TYPE_OPTIONS.map(opt => <option key={opt} value={opt}>{opt}</option>)}
                 </select>
                 <label
-                  className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap"
+                  className="flex items-center gap-2 text-sm text-text dark:text-text-light whitespace-nowrap"
                   title="Sort results to show unbranded foods before branded ones"
                 >
-                  <input type="checkbox" className="rounded text-indigo-600 focus:ring-indigo-500" checked={unbrandedFirst} onChange={(e) => setUnbrandedFirst(e.target.checked)} />
+                  <input type="checkbox" className="rounded text-brand-primary focus:ring-brand-primary" checked={unbrandedFirst} onChange={(e) => setUnbrandedFirst(e.target.checked)} />
                   Unbranded first
                 </label>
               </div>
               {allMyFoods.length > 0 && (
                 <div>
-                  <h4 className="font-semibold text-sm mb-1 text-gray-600 dark:text-gray-400">My Foods</h4>
-                  <ul className="border rounded-md divide-y dark:border-gray-600 dark:divide-gray-600 max-h-40 overflow-auto">
+                  <h4 className="font-semibold text-sm mb-1 text-text-muted dark:text-text-muted-dark">My Foods</h4>
+                  <ul className="border-border-light border rounded-md divide-y dark:border-border-dark dark:divide-border-dark max-h-40 overflow-auto">
                     {myFoodsFiltered.map((f) => (
-                      <li key={f.fdcId} className={`p-2 flex justify-between items-center cursor-pointer ${selected === f.fdcId ? 'bg-indigo-100 dark:bg-indigo-900' : 'hover:bg-gray-50 dark:hover:bg-gray-700'}`} onClick={() => setSelected(f.fdcId)}>
+                      <li key={f.fdcId} className={`p-2 flex justify-between items-center cursor-pointer ${selected === f.fdcId ? 'bg-brand-primary/20 dark:bg-brand-primary/30' : 'hover:bg-surface-light dark:hover:bg-border-dark'}`} onClick={() => setSelected(f.fdcId)}>
                         <div className="font-medium truncate text-sm">{f.description}</div>
-                        <button className="btn btn-ghost btn-sm text-red-600 hover:bg-red-50 dark:hover:bg-red-900/50" onClick={(e) => { e.stopPropagation(); handleDeleteCustomFood(f.fdcId); }}>🗑️</button>
+                        <button className="btn btn-ghost btn-sm text-brand-danger hover:bg-brand-danger/10 dark:hover:bg-brand-danger/30" onClick={(e) => { e.stopPropagation(); handleDeleteCustomFood(f.fdcId); }}>🗑️</button>
                       </li>
                     ))}
                   </ul>
                 </div>
               )}
               <div>
-                <h4 className="font-semibold text-sm mb-1 text-gray-600 dark:text-gray-400">USDA Results</h4>
-                <ul className="border rounded-md divide-y dark:border-gray-600 dark:divide-gray-600 h-[250px] overflow-auto">
-                  {searching ? (<li className="p-2 text-gray-500">Searching...</li>) :
+                  <h4 className="font-semibold text-sm mb-1 text-text-muted dark:text-text-muted-dark">USDA Results</h4>
+                <ul className="border-border-light border rounded-md divide-y dark:border-border-dark dark:divide-border-dark h-[250px] overflow-auto">
+                  {searching ? (<li className="p-2 text-text-muted">Searching...</li>) :
                     results.map(r => (
-                      <li key={r.fdcId} className={`p-2 cursor-pointer ${selected === r.fdcId ? 'bg-indigo-100 dark:bg-indigo-900' : 'hover:bg-gray-50 dark:hover:bg-gray-700'}`} onClick={() => setSelected(r.fdcId)}>
+                      <li key={r.fdcId} className={`p-2 cursor-pointer ${selected === r.fdcId ? 'bg-brand-primary/20 dark:bg-brand-primary/30' : 'hover:bg-surface-light dark:hover:bg-border-dark'}`} onClick={() => setSelected(r.fdcId)}>
                         <div className="font-medium text-sm">{r.description}</div>
-                        <div className="text-xs text-gray-500 dark:text-gray-400">{r.brandOwner || r.dataType}</div>
+                        <div className="text-xs text-text-muted dark:text-text-muted-dark">{r.brandOwner || r.dataType}</div>
                       </li>
                     ))}
                 </ul>
@@ -296,12 +296,12 @@ export function ControlPanel() {
           )}
           {tab === 'custom' && (
             <form onSubmit={handleSubmit(onCreateCustomFood)} className="space-y-4">
-              <div className="border-b pb-4 dark:border-gray-600">
-                <button type="button" className="text-sm font-medium text-indigo-600 dark:text-indigo-400 hover:underline" onClick={() => setUseLabel(v => !v)}>
+              <div className="border-b border-border-light pb-4 dark:border-border-dark">
+                <button type="button" className="text-sm font-medium text-brand-primary dark:text-brand-primary hover:underline" onClick={() => setUseLabel(v => !v)}>
                   {useLabel ? '⏷ Hide Converter' : '⏵ Convert from a nutrition label'}
                 </button>
                 {useLabel && (
-                  <div className="mt-2 p-3 border rounded-md bg-gray-50 dark:bg-gray-700/50 dark:border-gray-600 space-y-3">
+                  <div className="mt-2 p-3 border border-border-light rounded-md bg-surface-light dark:bg-border-dark/50 dark:border-border-dark space-y-3">
                     <div className="grid grid-cols-2 gap-2">
                       <input className="form-input" type="number" step="0.01" placeholder="kcal / serv" {...register('labelKcal', { valueAsNumber: true })} />
                       <input className="form-input" type="number" step="0.01" placeholder="protein g" {...register('labelP', { valueAsNumber: true })} />
@@ -321,7 +321,7 @@ export function ControlPanel() {
                         <button className="btn btn-secondary btn-sm" type="button" onClick={applyConverterValues}>
                           Apply ↓
                         </button>
-                        <div className="text-xs text-gray-600 dark:text-gray-400">
+                        <div className="text-xs text-text-muted dark:text-text-muted-dark">
                           <b>Per 100g:</b> {labelPer100.kcal.toFixed(0)}kcal, {labelPer100.fat.toFixed(1)}F, {labelPer100.carb.toFixed(1)}C, {labelPer100.protein.toFixed(1)}P
                         </div>
                       </div>
@@ -330,10 +330,10 @@ export function ControlPanel() {
                 )}
               </div>
               <div className="space-y-2">
-                <h4 className="font-medium text-sm dark:text-gray-300">Create Food (values per 100g)</h4>
+                <h4 className="font-medium text-sm text-text dark:text-text-light">Create Food (values per 100g)</h4>
                 <div>
                   <input className="form-input" placeholder="Description (e.g., Pop-Tarts)" {...register('description', { required: 'Description is required' })} />
-                  {errors.description && <p className="text-xs text-red-500 mt-1">{errors.description.message}</p>}
+                  {errors.description && <p className="text-xs text-brand-danger mt-1">{errors.description.message}</p>}
                 </div>
                 <input className="form-input" placeholder="Brand / store (optional)" {...register('brand_owner')} />
                 <div className="grid grid-cols-2 gap-2">
@@ -360,15 +360,15 @@ export function ControlPanel() {
               </div>
               <div className="max-h-64 overflow-auto">
                 <table className="w-full text-sm">
-                  <thead className="bg-gray-50 dark:bg-gray-700/50"><tr><th className="text-left p-2">Name</th><th className="p-2 text-right">Actions</th></tr></thead>
+                  <thead className="bg-surface-light dark:bg-border-dark/50"><tr><th className="text-left p-2">Name</th><th className="p-2 text-right">Actions</th></tr></thead>
                   <tbody>
                     {presets.map((p) => (
-                      <tr key={p.id} className="border-t dark:border-gray-600">
+                      <tr key={p.id} className="border-t border-border-light dark:border-border-dark">
                         <td className="p-2">{p.name} ({p.item_count})</td>
                         <td className="p-2 text-right">
                           <div className="flex gap-1 justify-end">
                             <button className="btn btn-ghost btn-sm" onClick={() => applyPreset(p.id)}>Apply</button>
-                            <button className="btn btn-ghost btn-sm text-red-600 hover:bg-red-50 dark:hover:bg-red-900/50" onClick={async () => {
+                            <button className="btn btn-ghost btn-sm text-brand-danger hover:bg-brand-danger/10 dark:hover:bg-brand-danger/30" onClick={async () => {
                               if (!confirm(`Delete preset \"${p.name}\"?`)) return;
                               await api.deletePreset(p.id);
                               await refreshPresets();

--- a/web/src/components/DailyLog.tsx
+++ b/web/src/components/DailyLog.tsx
@@ -109,20 +109,20 @@ function MealCard({ meal, isCurrent, onSelect, onUpdateEntry, onDeleteEntry, onD
   };
   return (
     <div
-      className={`card ${isCurrent ? "ring-2 ring-indigo-500" : ""}`}
+      className={`card ${isCurrent ? "ring-2 ring-brand-primary" : ""}`}
       draggable
       onDragStart={onDragStart}
       onDragOver={e => e.preventDefault()}
       onDrop={onDrop}
     >
-      <div className="card-header bg-gray-100 dark:bg-gray-700 flex items-center relative py-3" onClick={!isRenaming ? onSelect : undefined}>
+      <div className="card-header bg-surface-light dark:bg-border-dark flex items-center relative py-3" onClick={!isRenaming ? onSelect : undefined}>
         {isRenaming ? (
           <form className="flex-1 flex items-center gap-2" onSubmit={e => { e.preventDefault(); submitRename(); }}>
             <input className="form-input flex-1 py-1" value={tempName} onChange={e => setTempName(e.target.value)} autoFocus />
             <button type="submit" className="btn btn-secondary btn-sm">Save</button>
           </form>
         ) : (
-          <h3 className="flex-1 text-center font-semibold text-lg dark:text-gray-200">{meal.name}</h3>
+          <h3 className="flex-1 text-center font-semibold text-lg dark:text-text-light">{meal.name}</h3>
         )}
         <div className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-1">
             <button type="button" title="Rename meal" onClick={(e) => { e.stopPropagation(); setIsRenaming(true); }} className="btn btn-ghost btn-sm">✏️</button>
@@ -146,7 +146,7 @@ function MealCard({ meal, isCurrent, onSelect, onUpdateEntry, onDeleteEntry, onD
             <col className="w-36" />
           </colgroup>
           <thead>
-            <tr className="border-b dark:border-gray-600">
+            <tr className="border-b border-border-light dark:border-border-dark">
               <th className="text-left p-3 font-medium">Item</th>
               <th className="text-right p-3 font-medium">Qty (g)</th>
               <th className="text-right p-3 font-medium">kcal</th>
@@ -158,10 +158,10 @@ function MealCard({ meal, isCurrent, onSelect, onUpdateEntry, onDeleteEntry, onD
           </thead>
           <tbody>
             {meal.entries.length ? (meal.entries.map(e => (<Row key={e.id} e={e} onUpdate={onUpdateEntry} onDelete={onDeleteEntry} />))) :
-              (<tr><td className="p-4 text-gray-500 text-center" colSpan={7}>No entries yet.</td></tr>)}
+              (<tr><td className="p-4 text-text-muted text-center" colSpan={7}>No entries yet.</td></tr>)}
           </tbody>
           <tfoot>
-            <tr className="font-semibold border-t-2 border-gray-200 dark:border-gray-600">
+            <tr className="font-semibold border-t-2 border-border-light dark:border-border-dark">
                 <td className="p-3 text-right" colSpan={2}>Subtotal</td>
                 <td className="p-3 text-right subtotal-kcal">{meal.subtotal.kcal.toFixed(1)}</td>
                 <td className="p-3 text-right subtotal-fat">{meal.subtotal.fat.toFixed(1)}</td>
@@ -209,7 +209,7 @@ function Row({ e, onUpdate, onDelete }: RowProps) {
   }
 
   return (
-    <tr className="border-t dark:border-gray-700">
+    <tr className="border-t border-border-light dark:border-border-dark">
       <td className="p-2 text-left font-medium">{e.description}</td>
       <td className="p-2 text-right"><input className="form-input text-right w-20 py-1" type="number" min={1} step={1} value={g} onChange={ev=>setG(parseFloat(ev.target.value))} disabled={isMutating} /></td>
       <td className="p-2 text-right">{e.kcal.toFixed(1)}</td>
@@ -219,7 +219,7 @@ function Row({ e, onUpdate, onDelete }: RowProps) {
       <td className="p-2 text-right">
         <div className="flex gap-2 justify-end">
           <button className="btn btn-secondary btn-sm" disabled={!changed || isNaN(g) || g <= 0 || isMutating} onClick={handleUpdate}>{isMutating ? "..." : "Update"}</button>
-          <button className="btn btn-ghost btn-sm text-red-600 hover:bg-red-50 dark:hover:bg-red-900/50" onClick={handleDelete} disabled={isMutating}>{isMutating ? "..." : "Delete"}</button>
+          <button className="btn btn-ghost btn-sm text-brand-danger hover:bg-brand-danger/10 dark:hover:bg-brand-danger/30" onClick={handleDelete} disabled={isMutating}>{isMutating ? "..." : "Delete"}</button>
         </div>
       </td>
     </tr>

--- a/web/src/components/LoadingSpinner.tsx
+++ b/web/src/components/LoadingSpinner.tsx
@@ -1,7 +1,7 @@
 export function LoadingSpinner() {
     return (
         <div className="flex h-full items-center justify-center">
-            <div className="h-12 w-12 animate-spin rounded-full border-4 border-gray-300 border-t-blue-500"></div>
+            <div className="h-12 w-12 animate-spin rounded-full border-4 border-border-light border-t-brand-primary"></div>
         </div>
     );
 }

--- a/web/src/components/RadialProgress.tsx
+++ b/web/src/components/RadialProgress.tsx
@@ -17,7 +17,7 @@ export function RadialProgress({ value, goal, color, decimals = 0, unit = "" }: 
             <div className="relative w-20 h-20">
                 <svg className="w-20 h-20" viewBox="0 0 64 64">
                     <circle
-                        className="text-gray-200 dark:text-gray-700"
+                        className="text-border-light dark:text-border-dark"
                         strokeWidth="4"
                         stroke="currentColor"
                         fill="transparent"
@@ -39,12 +39,12 @@ export function RadialProgress({ value, goal, color, decimals = 0, unit = "" }: 
                         transform="rotate(-90 32 32)"
                     />
                 </svg>
-                <div className="absolute inset-0 flex items-center justify-center text-sm font-bold text-gray-900 dark:text-gray-100">
+                <div className="absolute inset-0 flex items-center justify-center text-sm font-bold text-text dark:text-text-light">
                     {value.toFixed(decimals)}{unit}
                 </div>
             </div>
             {goal > 0 && (
-                <div className="text-xs mt-1 text-gray-700 dark:text-gray-300">
+                <div className="text-xs mt-1 text-text dark:text-text-light">
                     {value.toFixed(decimals)}{unit} / {goal}{unit}
                 </div>
             )}

--- a/web/src/components/Summary.tsx
+++ b/web/src/components/Summary.tsx
@@ -16,41 +16,41 @@ export function Summary() {
     return (
         <div>
             <div className="sticky top-6 card">
-                <div className="card-header"><h2 className="font-semibold text-lg dark:text-gray-200">Today's Totals</h2></div>
+                <div className="card-header"><h2 className="font-semibold text-lg dark:text-text-light">Today's Totals</h2></div>
                 <div className="card-body">
                     <div className="flex justify-between items-stretch gap-2">
                         {/* kcal */}
-                        <div className="flex-1 bg-indigo-50 dark:bg-indigo-900/50 p-3 rounded-lg text-center transition-shadow hover:shadow-md">
-                            <div className="text-sm text-indigo-800 dark:text-indigo-200 mb-2">kcal</div>
-                            <RadialProgress value={totals?.kcal ?? 0} goal={goals.kcal} color="text-indigo-500" decimals={0} />
+                        <div className="flex-1 bg-brand-primary/10 dark:bg-brand-primary/30 p-3 rounded-lg text-center transition-shadow hover:shadow-md">
+                            <div className="text-sm text-brand-primary dark:text-brand-primary mb-2">kcal</div>
+                            <RadialProgress value={totals?.kcal ?? 0} goal={goals.kcal} color="text-brand-primary" decimals={0} />
                         </div>
 
                         {/* fat */}
-                        <div className="flex-1 bg-yellow-50 dark:bg-yellow-900/50 p-3 rounded-lg text-center transition-shadow hover:shadow-md">
-                            <div className="text-sm text-yellow-800 dark:text-yellow-200 mb-2">Fat</div>
-                            <RadialProgress value={totals?.fat ?? 0} goal={goals.fat} color="text-yellow-500" decimals={1} unit="g" />
+                        <div className="flex-1 bg-brand-warning/10 dark:bg-brand-warning/30 p-3 rounded-lg text-center transition-shadow hover:shadow-md">
+                            <div className="text-sm text-brand-warning dark:text-brand-warning mb-2">Fat</div>
+                            <RadialProgress value={totals?.fat ?? 0} goal={goals.fat} color="text-brand-warning" decimals={1} unit="g" />
                         </div>
 
                         {/* carb */}
-                        <div className="flex-1 bg-red-50 dark:bg-red-900/50 p-3 rounded-lg text-center transition-shadow hover:shadow-md">
-                            <div className="text-sm text-red-800 dark:text-red-200 mb-2">Carb</div>
-                            <RadialProgress value={totals?.carb ?? 0} goal={goals.carb} color="text-red-500" decimals={1} unit="g" />
+                        <div className="flex-1 bg-brand-danger/10 dark:bg-brand-danger/30 p-3 rounded-lg text-center transition-shadow hover:shadow-md">
+                            <div className="text-sm text-brand-danger dark:text-brand-danger mb-2">Carb</div>
+                            <RadialProgress value={totals?.carb ?? 0} goal={goals.carb} color="text-brand-danger" decimals={1} unit="g" />
                         </div>
 
                         {/* protein */}
-                        <div className="flex-1 bg-green-50 dark:bg-green-900/50 p-3 rounded-lg text-center transition-shadow hover:shadow-md">
-                            <div className="text-sm text-green-800 dark:text-green-200 mb-2">Protein</div>
-                            <RadialProgress value={totals?.protein ?? 0} goal={goals.protein} color="text-green-500" decimals={1} unit="g" />
+                        <div className="flex-1 bg-brand-success/10 dark:bg-brand-success/30 p-3 rounded-lg text-center transition-shadow hover:shadow-md">
+                            <div className="text-sm text-brand-success dark:text-brand-success mb-2">Protein</div>
+                            <RadialProgress value={totals?.protein ?? 0} goal={goals.protein} color="text-brand-success" decimals={1} unit="g" />
                         </div>
                     </div>
                     <div className="mt-6">
-                        <label className="block mb-1 text-sm text-gray-700 dark:text-gray-300">Body Weight (lb)</label>
+                        <label className="block mb-1 text-sm text-text dark:text-text-light">Body Weight (lb)</label>
                         <div className="flex gap-2">
                             <input className="form-input flex-1" value={input} onChange={e => setInput(e.target.value)} />
                             <button className="btn btn-primary" onClick={() => { const v = parseFloat(input); if(!isNaN(v)) saveWeight(v); }}>Save</button>
                         </div>
                     </div>
-                    <div className="text-xs text-gray-500 mt-4 text-center">Calories for custom foods use the label; USDA items use 4/4/9.</div>
+                    <div className="text-xs text-text-muted mt-4 text-center">Calories for custom foods use the label; USDA items use 4/4/9.</div>
                 </div>
             </div>
         </div>

--- a/web/src/components/ThemeToggle.tsx
+++ b/web/src/components/ThemeToggle.tsx
@@ -6,7 +6,7 @@ export function ThemeToggle() {
     return (
         <button
             onClick={toggleTheme}
-            className="p-2 rounded-full text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-500"
+            className="p-2 rounded-full text-text-muted dark:text-text-muted-dark hover:bg-surface-light dark:hover:bg-surface-dark focus:outline-none focus:ring-2 focus:ring-brand-primary"
             aria-label="Toggle theme"
         >
             {theme === 'light' ? (

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -6,7 +6,7 @@
 
 @layer base {
   body {
-    @apply text-gray-800 dark:text-gray-300;
+    @apply font-sans text-text dark:text-text-light;
   }
 }
 

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -39,14 +39,14 @@ export function DashboardPage() {
                     <button
                         key={opt}
                         onClick={() => setDays(opt)}
-                        className={`px-3 py-1 rounded ${days === opt ? 'bg-blue-500 text-white' : 'bg-gray-200 dark:bg-gray-700'}`}
+                        className={`px-3 py-1 rounded ${days === opt ? 'bg-brand-primary text-text-light' : 'bg-surface-light dark:bg-border-dark'}`}
                     >
                         Last {opt} Days
                     </button>
                 ))}
             </div>
             <div className="card">
-                <div className="card-header"><h2 className="font-semibold text-lg dark:text-gray-200">Calorie Trend (Last {days} Days)</h2></div>
+                <div className="card-header"><h2 className="font-semibold text-lg dark:text-text-light">Calorie Trend (Last {days} Days)</h2></div>
                 <div className="card-body h-80">
                     {loading ? (
                         <LoadingSpinner />
@@ -68,7 +68,7 @@ export function DashboardPage() {
                 </div>
             </div>
             <div className="card">
-                <div className="card-header"><h2 className="font-semibold text-lg dark:text-gray-200">Macro Trend (Last {days} Days)</h2></div>
+                <div className="card-header"><h2 className="font-semibold text-lg dark:text-text-light">Macro Trend (Last {days} Days)</h2></div>
                 <div className="card-body h-80">
                     {loading ? (
                         <LoadingSpinner />
@@ -92,7 +92,7 @@ export function DashboardPage() {
                 </div>
             </div>
             <div className="card">
-                <div className="card-header"><h2 className="font-semibold text-lg dark:text-gray-200">Body Weight Trend (Last {days} Days)</h2></div>
+                <div className="card-header"><h2 className="font-semibold text-lg dark:text-text-light">Body Weight Trend (Last {days} Days)</h2></div>
                 <div className="card-body h-80">
                     {loading ? (
                         <LoadingSpinner />

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -14,7 +14,33 @@ export default {
     path.resolve(__dirname, "./src/**/*.{js,ts,jsx,tsx}"),
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        brand: {
+          primary: '#6366f1',
+          success: '#82ca9d',
+          warning: '#ffc658',
+          danger: '#ff8042',
+        },
+        surface: {
+          light: '#f3f4f6',
+          dark: '#111827',
+        },
+        text: {
+          DEFAULT: '#1f2937',
+          light: '#f3f4f6',
+          muted: '#6b7280',
+          'muted-dark': '#9ca3af',
+        },
+        border: {
+          light: '#e5e7eb',
+          dark: '#4b5563',
+        },
+      },
+      fontFamily: {
+        sans: ['Poppins', 'sans-serif'],
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- extend Tailwind theme with brand color palette and Poppins font
- load Poppins from Google Fonts and apply across the app
- replace hard-coded color classes with semantic brand tokens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Package subpath './config' is not defined by "exports" in eslint package)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6899082f96fc8327ac0687a0f2ecb278