### PR TITLE
Add layout component and 404 page

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,18 +1,14 @@
-// web/src/App.tsx (replace entire file)
-
 import { useEffect, useState } from "react";
-import { Toaster } from 'react-hot-toast';
-import { BrowserRouter, Routes, Route, NavLink } from "react-router-dom";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { useStore } from "./store";
-import { ThemeToggle } from "./components/ThemeToggle";
 import { TrackerPage } from "./pages/TrackerPage";
 import { DashboardPage } from "./pages/DashboardPage";
-import { Bars3Icon, XMarkIcon, HomeIcon, ChartBarIcon } from "@heroicons/react/24/outline";
+import { NotFoundPage } from "./pages/NotFoundPage";
+import { Layout } from "./components/Layout";
 import { LoadingSpinner } from "./components/LoadingSpinner";
 
 export default function App() {
   const init = useStore(state => state.init);
-  const [menuOpen, setMenuOpen] = useState(false);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -27,69 +23,15 @@ export default function App() {
     );
   }
 
-  const navLinkClass = ({ isActive }: { isActive: boolean }) =>
-    `flex items-center gap-2 px-4 py-2 rounded-md text-sm font-semibold transition-colors ${
-      isActive
-        ? 'bg-brand-primary text-text-light'
-        : 'text-text dark:text-text-light hover:bg-surface-light dark:hover:bg-border-dark'
-    }`;
-
-  const navItems = [
-    { to: '/', label: 'Tracker', icon: HomeIcon },
-    { to: '/dashboard', label: 'Dashboard', icon: ChartBarIcon }
-  ];
-
   return (
     <BrowserRouter>
-      <div className="min-h-screen bg-surface-light dark:bg-surface-dark font-sans">
-        <Toaster position="bottom-center" toastOptions={{ style: { background: '#363636', color: '#fff' }, success: { duration: 3000 } }} />
-
-        <header className="sticky top-0 z-10 bg-surface-light dark:bg-surface-dark">
-          <div className="mx-auto flex items-center justify-between px-4 py-4 lg:px-6">
-            <div className="flex items-center gap-2">
-              <button className="lg:hidden text-text dark:text-text-light" onClick={() => setMenuOpen(true)}>
-                <Bars3Icon className="h-6 w-6" />
-              </button>
-              <h1 className="text-xl lg:text-3xl font-bold text-text dark:text-text-light">Macro Tracker</h1>
-            </div>
-            <div className="flex items-center gap-4">
-              <nav className="hidden lg:flex items-center gap-4">
-                {navItems.map(({ to, label, icon: Icon }) => (
-                  <NavLink key={to} to={to} className={navLinkClass}>
-                    <Icon className="h-5 w-5" />
-                    {label}
-                  </NavLink>
-                ))}
-              </nav>
-              <ThemeToggle />
-            </div>
-          </div>
-        </header>
-
-        <div className={`fixed inset-0 z-20 transform transition-transform duration-200 lg:hidden ${menuOpen ? 'translate-x-0' : '-translate-x-full'}`}>
-          <div className="absolute inset-0 bg-black/50" onClick={() => setMenuOpen(false)}></div>
-          <div className="relative bg-surface-light dark:bg-surface-dark w-64 h-full p-4">
-            <button className="mb-4 text-text dark:text-text-light" onClick={() => setMenuOpen(false)}>
-              <XMarkIcon className="h-6 w-6" />
-            </button>
-            <nav className="flex flex-col gap-2">
-              {navItems.map(({ to, label, icon: Icon }) => (
-                <NavLink key={to} to={to} className={navLinkClass} onClick={() => setMenuOpen(false)}>
-                  <Icon className="h-5 w-5" />
-                  {label}
-                </NavLink>
-              ))}
-            </nav>
-          </div>
-        </div>
-
-        <main className="mx-auto px-4 py-6 lg:px-6">
-          <Routes>
-            <Route path="/" element={<TrackerPage />} />
-            <Route path="/dashboard" element={<DashboardPage />} />
-          </Routes>
-        </main>
-      </div>
+      <Layout>
+        <Routes>
+          <Route path="/" element={<TrackerPage />} />
+          <Route path="/dashboard" element={<DashboardPage />} />
+          <Route path="*" element={<NotFoundPage />} />
+        </Routes>
+      </Layout>
     </BrowserRouter>
   );
 }

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from "react";
+import { NavLink } from "react-router-dom";
+import { Toaster } from 'react-hot-toast';
+import { ThemeToggle } from "./ThemeToggle";
+import { Bars3Icon, XMarkIcon, HomeIcon, ChartBarIcon } from "@heroicons/react/24/outline";
+
+interface LayoutProps {
+  children: React.ReactNode;
+}
+
+export function Layout({ children }: LayoutProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setMenuOpen(false);
+      }
+    };
+
+    if (menuOpen) {
+      document.body.classList.add('overflow-hidden');
+      document.addEventListener('keydown', handleKeyDown);
+    } else {
+      document.body.classList.remove('overflow-hidden');
+    }
+
+    return () => {
+      document.body.classList.remove('overflow-hidden');
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [menuOpen]);
+
+  const navLinkClass = ({ isActive }: { isActive: boolean }) =>
+    `flex items-center gap-2 px-4 py-2 rounded-md text-sm font-semibold transition-colors ${
+      isActive
+        ? 'bg-brand-primary text-text-light'
+        : 'text-text dark:text-text-light hover:bg-surface-light dark:hover:bg-border-dark'
+    }`;
+
+  const navItems = [
+    { to: '/', label: 'Tracker', icon: HomeIcon },
+    { to: '/dashboard', label: 'Dashboard', icon: ChartBarIcon }
+  ];
+
+  return (
+    <div className="min-h-screen bg-surface-light dark:bg-surface-dark font-sans">
+      <Toaster position="bottom-center" toastOptions={{ style: { background: '#363636', color: '#fff' }, success: { duration: 3000 } }} />
+
+      <header className="sticky top-0 z-10 bg-surface-light dark:bg-surface-dark">
+        <div className="mx-auto flex items-center justify-between px-4 py-4 lg:px-6">
+          <div className="flex items-center gap-2">
+            <button className="lg:hidden text-text dark:text-text-light" onClick={() => setMenuOpen(true)}>
+              <Bars3Icon className="h-6 w-6" />
+            </button>
+            <h1 className="text-xl lg:text-3xl font-bold text-text dark:text-text-light">Macro Tracker</h1>
+          </div>
+          <div className="flex items-center gap-4">
+            <nav className="hidden lg:flex items-center gap-4">
+              {navItems.map(({ to, label, icon: Icon }) => (
+                <NavLink key={to} to={to} className={navLinkClass}>
+                  <Icon className="h-5 w-5" />
+                  {label}
+                </NavLink>
+              ))}
+            </nav>
+            <ThemeToggle />
+          </div>
+        </div>
+      </header>
+
+      <div className={`fixed inset-0 z-20 transform transition-transform duration-200 lg:hidden ${menuOpen ? 'translate-x-0' : '-translate-x-full'}`}>
+        <div className="absolute inset-0 bg-black/50" onClick={() => setMenuOpen(false)}></div>
+        <div className="relative bg-surface-light dark:bg-surface-dark w-64 h-full p-4">
+          <button className="mb-4 text-text dark:text-text-light" onClick={() => setMenuOpen(false)}>
+            <XMarkIcon className="h-6 w-6" />
+          </button>
+          <nav className="flex flex-col gap-2">
+            {navItems.map(({ to, label, icon: Icon }) => (
+              <NavLink key={to} to={to} className={navLinkClass} onClick={() => setMenuOpen(false)}>
+                <Icon className="h-5 w-5" />
+                {label}
+              </NavLink>
+            ))}
+          </nav>
+        </div>
+      </div>
+
+      <main className="mx-auto px-4 py-6 lg:px-6">{children}</main>
+    </div>
+  );
+}
+

--- a/web/src/pages/NotFoundPage.tsx
+++ b/web/src/pages/NotFoundPage.tsx
@@ -1,0 +1,10 @@
+import { Link } from "react-router-dom";
+
+export function NotFoundPage() {
+  return (
+    <div className="text-center">
+      <h2 className="text-2xl font-bold mb-4">Page Not Found</h2>
+      <Link to="/" className="text-brand-primary underline">Return Home</Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Extract reusable Layout with header, navigation and mobile side drawer that locks body scroll and closes on Escape
- Wrap routes in Layout and add catch-all route
- Create NotFoundPage with link back home

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED])*

------
https://chatgpt.com/codex/tasks/task_e_68996e71b25883278e929d4c5e4b7503