### PR TITLE
feat(ui): add Button and Input components

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9,6 +9,7 @@ import { TrackerPage } from "./pages/TrackerPage";
 import { DashboardPage } from "./pages/DashboardPage";
 import { Bars3Icon, XMarkIcon, HomeIcon, ChartBarIcon } from "@heroicons/react/24/outline";
 import { LoadingSpinner } from "./components/LoadingSpinner";
+import { Button } from "./components/ui/Button";
 
 export default function App() {
   const init = useStore(state => state.init);
@@ -47,9 +48,9 @@ export default function App() {
         <header className="sticky top-0 z-10 bg-surface-light dark:bg-surface-dark">
           <div className="mx-auto flex items-center justify-between px-4 py-4 lg:px-6">
             <div className="flex items-center gap-2">
-              <button className="lg:hidden text-text dark:text-text-light" onClick={() => setMenuOpen(true)}>
+              <Button className="btn-ghost lg:hidden text-text dark:text-text-light" onClick={() => setMenuOpen(true)}>
                 <Bars3Icon className="h-6 w-6" />
-              </button>
+              </Button>
               <h1 className="text-xl lg:text-3xl font-bold text-text dark:text-text-light">Macro Tracker</h1>
             </div>
             <div className="flex items-center gap-4">
@@ -69,9 +70,9 @@ export default function App() {
         <div className={`fixed inset-0 z-20 transform transition-transform duration-200 lg:hidden ${menuOpen ? 'translate-x-0' : '-translate-x-full'}`}>
           <div className="absolute inset-0 bg-black/50" onClick={() => setMenuOpen(false)}></div>
           <div className="relative bg-surface-light dark:bg-surface-dark w-64 h-full p-4">
-            <button className="mb-4 text-text dark:text-text-light" onClick={() => setMenuOpen(false)}>
+            <Button className="btn-ghost mb-4 text-text dark:text-text-light" onClick={() => setMenuOpen(false)}>
               <XMarkIcon className="h-6 w-6" />
-            </button>
+            </Button>
             <nav className="flex flex-col gap-2">
               {navItems.map(({ to, label, icon: Icon }) => (
                 <NavLink key={to} to={to} className={navLinkClass} onClick={() => setMenuOpen(false)}>

--- a/web/src/components/DailyLog.tsx
+++ b/web/src/components/DailyLog.tsx
@@ -2,6 +2,8 @@ import { useMemo, useState, useEffect } from "react";
 import toast from 'react-hot-toast';
 import { useStore } from "../store";
 import type { MealType } from "../types";
+import { Button } from "./ui/Button";
+import { Input } from "./ui/Input";
 
 export function DailyLog() {
   const { day, mealName, setDate, setMealName, addMeal, updateEntry, deleteEntry, deleteMeal, renameMeal, moveMeal, copiedMealId, copyMeal, pasteMeal } = useStore();
@@ -45,7 +47,7 @@ export function DailyLog() {
         <div className="card-body flex flex-wrap items-center justify-between gap-4">
           <div className="flex items-center gap-2">
             <label htmlFor="date-picker" className="font-semibold text-sm">Date:</label>
-            <input id="date-picker" className="form-input" type="date" value={day?.date ?? new Date().toISOString().slice(0, 10)} onChange={e => setDate(e.target.value)} />
+            <Input id="date-picker" type="date" value={day?.date ?? new Date().toISOString().slice(0, 10)} onChange={e => setDate(e.target.value)} />
           </div>
           <div className="flex items-center gap-2">
             <select className="form-input" value={mealName} onChange={e => setMealName(e.target.value)}>
@@ -53,14 +55,14 @@ export function DailyLog() {
             </select>
             
             {copiedMealId && (
-              <button type="button" className="btn btn-secondary whitespace-nowrap" onClick={handlePasteMeal} disabled={isPasting}>
+              <Button type="button" className="btn-secondary whitespace-nowrap" onClick={handlePasteMeal} disabled={isPasting}>
                 {isPasting ? "Pasting..." : `Paste to ${mealName}`}
-              </button>
+              </Button>
             )}
 
-            <button type="button" className="btn btn-secondary" onClick={handleAddMeal} disabled={isAddingMeal}>
+            <Button type="button" className="btn-secondary" onClick={handleAddMeal} disabled={isAddingMeal}>
               {isAddingMeal ? "+ ..." : "+ Meal"}
-            </button>
+            </Button>
           </div>
         </div>
       </div>
@@ -118,41 +120,41 @@ function MealCard({ meal, isCurrent, onSelect, onUpdateEntry, onDeleteEntry, onD
       <div className="card-header bg-surface-light dark:bg-border-dark flex items-center relative py-3" onClick={!isRenaming ? onSelect : undefined}>
         {isRenaming ? (
           <form className="flex-1 flex items-center gap-2" onSubmit={e => { e.preventDefault(); submitRename(); }}>
-            <input className="form-input flex-1 py-1" value={tempName} onChange={e => setTempName(e.target.value)} autoFocus />
-            <button type="submit" className="btn btn-secondary btn-sm">Save</button>
+            <Input className="flex-1 py-1" value={tempName} onChange={e => setTempName(e.target.value)} autoFocus />
+            <Button type="submit" className="btn-secondary btn-sm">Save</Button>
           </form>
         ) : (
           <h3 className="flex-1 text-center font-semibold text-lg dark:text-text-light">{meal.name}</h3>
         )}
         <div className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-1">
-            <button
+            <Button
               type="button"
               title="Rename meal"
               aria-label="Rename meal"
               onClick={(e) => { e.stopPropagation(); setIsRenaming(true); }}
-              className="btn btn-ghost btn-sm"
+              className="btn-ghost btn-sm"
             >
               ✏️
-            </button>
-            <button
+            </Button>
+            <Button
               type="button"
               title="Copy meal"
               aria-label="Copy meal"
               onClick={(e) => { e.stopPropagation(); onCopyMeal(meal.id); }}
-              className="btn btn-ghost btn-sm"
+              className="btn-ghost btn-sm"
             >
                 <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>
-            </button>
+            </Button>
             {meal.entries.length === 0 && (
-              <button
+              <Button
                 type="button"
                 title="Delete empty meal"
                 aria-label="Delete empty meal"
                 onClick={(e) => { e.stopPropagation(); onDeleteMeal(meal.id); }}
-                className="btn btn-ghost btn-sm"
+                className="btn-ghost btn-sm"
               >
                 🗑️
-              </button>
+              </Button>
             )}
         </div>
       </div>
@@ -239,9 +241,9 @@ function Row({ e, onUpdate, onDelete }: RowProps) {
           return (
             <>
               <label htmlFor={id} className="sr-only">Quantity in grams</label>
-              <input
+              <Input
                 id={id}
-                className="form-input text-right w-20 py-1"
+                className="text-right w-20 py-1"
                 type="number"
                 min={1}
                 step={1}
@@ -259,8 +261,8 @@ function Row({ e, onUpdate, onDelete }: RowProps) {
       <td className="p-2 text-right">{e.protein.toFixed(1)}</td>
       <td className="p-2 text-right">
         <div className="flex gap-2 justify-end">
-          <button className="btn btn-secondary btn-sm" disabled={!changed || isNaN(g) || g <= 0 || isMutating} onClick={handleUpdate}>{isMutating ? "..." : "Update"}</button>
-          <button className="btn btn-ghost btn-sm text-brand-danger hover:bg-brand-danger/10 dark:hover:bg-brand-danger/30" onClick={handleDelete} disabled={isMutating}>{isMutating ? "..." : "Delete"}</button>
+          <Button className="btn-secondary btn-sm" disabled={!changed || isNaN(g) || g <= 0 || isMutating} onClick={handleUpdate}>{isMutating ? "..." : "Update"}</Button>
+          <Button className="btn-ghost btn-sm text-brand-danger hover:bg-brand-danger/10 dark:hover:bg-brand-danger/30" onClick={handleDelete} disabled={isMutating}>{isMutating ? "..." : "Delete"}</Button>
         </div>
       </td>
     </tr>

--- a/web/src/components/Summary.tsx
+++ b/web/src/components/Summary.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from "react";
 import { useStore } from "../store";
 import RadialProgress from "./RadialProgress";
+import { Button } from "./ui/Button";
+import { Input } from "./ui/Input";
 
 export function Summary() {
     const totals = useStore(state => state.day?.totals);
@@ -46,19 +48,19 @@ export function Summary() {
                     <div className="mt-6">
                         <label htmlFor="body-weight" className="block mb-1 text-sm text-text dark:text-text-light">Body Weight (lb)</label>
                         <div className="flex gap-2">
-                            <input
+                            <Input
                                 id="body-weight"
-                                className="form-input flex-1"
+                                className="flex-1"
                                 value={input}
                                 onChange={e => setInput(e.target.value)}
                             />
-                            <button
-                                className="btn btn-primary"
+                            <Button
+                                className="btn-primary"
                                 aria-label="Save weight"
                                 onClick={() => { const v = parseFloat(input); if(!isNaN(v)) saveWeight(v); }}
                             >
                                 Save
-                            </button>
+                            </Button>
                         </div>
                     </div>
                     <div className="text-xs text-text-muted mt-4 text-center">Calories for custom foods use the label; USDA items use 4/4/9.</div>

--- a/web/src/components/ThemeToggle.tsx
+++ b/web/src/components/ThemeToggle.tsx
@@ -1,12 +1,13 @@
 import { useStore } from "../store";
+import { Button } from "./ui/Button";
 
 export function ThemeToggle() {
     const { theme, toggleTheme } = useStore();
 
     return (
-        <button
+        <Button
             onClick={toggleTheme}
-            className="p-2 rounded-full text-text-muted dark:text-text-muted-dark hover:bg-surface-light dark:hover:bg-surface-dark focus:outline-none focus:ring-2 focus:ring-brand-primary"
+            className="btn-ghost p-2 rounded-full text-text-muted dark:text-text-muted-dark hover:bg-surface-light dark:hover:bg-surface-dark focus:outline-none focus:ring-2 focus:ring-brand-primary"
             aria-label="Toggle theme"
         >
             {theme === 'light' ? (
@@ -18,6 +19,6 @@ export function ThemeToggle() {
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
                 </svg>
             )}
-        </button>
+        </Button>
     );
 }

--- a/web/src/components/control-panel/ControlPanel.tsx
+++ b/web/src/components/control-panel/ControlPanel.tsx
@@ -4,6 +4,7 @@ import { CustomFoodTab } from "./CustomFoodTab";
 import { PresetsTab } from "./PresetsTab";
 import { GoalsTab } from "./GoalsTab";
 import { ExportTab } from "./ExportTab";
+import { Button } from "../ui/Button";
 
 type TabKey = 'search' | 'custom' | 'presets' | 'goals' | 'export';
 const tabs: { key: TabKey; label: string }[] = [
@@ -23,17 +24,17 @@ export function ControlPanel() {
         <div className="card-header p-0">
           <div className="flex">
             {tabs.map(t => (
-              <button
+              <Button
                 key={t.key}
                 onClick={() => setTab(t.key)}
-                className={`flex-1 px-3 py-2 text-sm font-medium border-b-2 ${
+                className={`btn-ghost flex-1 px-3 py-2 text-sm font-medium border-b-2 ${
                   tab === t.key
                     ? 'border-brand-primary text-brand-primary'
                     : 'border-transparent text-text-muted hover:text-text dark:hover:text-text-light'
                 }`}
               >
                 {t.label}
-              </button>
+              </Button>
             ))}
           </div>
         </div>

--- a/web/src/components/control-panel/CustomFoodTab.tsx
+++ b/web/src/components/control-panel/CustomFoodTab.tsx
@@ -4,6 +4,8 @@ import toast from 'react-hot-toast';
 import { useStore } from "../../store";
 import * as api from "../../api";
 import type { LabelUnit, SimpleFood } from "../../types";
+import { Button } from "../ui/Button";
+import { Input } from "../ui/Input";
 
 function toSimpleFood(f: any): SimpleFood {
   return {
@@ -97,34 +99,34 @@ export function CustomFoodTab() {
   return (
     <form onSubmit={handleSubmit(onCreateCustomFood)} className="space-y-4">
       <div className="border-b border-border-light pb-4 dark:border-border-dark">
-        <button type="button" className="text-sm font-medium text-brand-primary dark:text-brand-primary hover:underline" onClick={() => setUseLabel(v => !v)}>
+        <Button type="button" className="btn-ghost btn-sm text-brand-primary dark:text-brand-primary hover:underline" onClick={() => setUseLabel(v => !v)}>
           {useLabel ? '⏷ Hide Converter' : '⏵ Convert from a nutrition label'}
-        </button>
+        </Button>
         {useLabel && (
           <div className="mt-2 p-3 border border-border-light rounded-md bg-surface-light dark:bg-border-dark/50 dark:border-border-dark space-y-3">
             <div className="grid grid-cols-2 gap-2">
               <div className="flex flex-col">
                 <label htmlFor={ids.labelKcal} className="sr-only">kcal per serving</label>
-                <input id={ids.labelKcal} className="form-input" type="number" step="0.01" placeholder="kcal / serv" {...register('labelKcal', { valueAsNumber: true })} />
+                <Input id={ids.labelKcal} type="number" step={0.01} placeholder="kcal / serv" {...register('labelKcal', { valueAsNumber: true })} />
               </div>
               <div className="flex flex-col">
                 <label htmlFor={ids.labelP} className="sr-only">protein grams</label>
-                <input id={ids.labelP} className="form-input" type="number" step="0.01" placeholder="protein g" {...register('labelP', { valueAsNumber: true })} />
+                <Input id={ids.labelP} type="number" step={0.01} placeholder="protein g" {...register('labelP', { valueAsNumber: true })} />
               </div>
               <div className="flex flex-col">
                 <label htmlFor={ids.labelF} className="sr-only">fat grams</label>
-                <input id={ids.labelF} className="form-input" type="number" step="0.01" placeholder="fat g" {...register('labelF', { valueAsNumber: true })} />
+                <Input id={ids.labelF} type="number" step={0.01} placeholder="fat g" {...register('labelF', { valueAsNumber: true })} />
               </div>
               <div className="flex flex-col">
                 <label htmlFor={ids.labelC} className="sr-only">carb grams</label>
-                <input id={ids.labelC} className="form-input" type="number" step="0.01" placeholder="carb g" {...register('labelC', { valueAsNumber: true })} />
+                <Input id={ids.labelC} type="number" step={0.01} placeholder="carb g" {...register('labelC', { valueAsNumber: true })} />
               </div>
             </div>
             <div className="flex flex-wrap items-center gap-2">
               <span className="text-sm">per</span>
               <div className="flex flex-col">
                 <label htmlFor={ids.servAmt} className="sr-only">Serving size</label>
-                <input id={ids.servAmt} className="form-input w-24" type="number" min={0} step="0.01" placeholder="Serv size" {...register('servAmt', { valueAsNumber: true })} />
+                <Input id={ids.servAmt} className="w-24" type="number" min={0} step={0.01} placeholder="Serv size" {...register('servAmt', { valueAsNumber: true })} />
               </div>
               <div className="flex flex-col flex-1">
                 <label htmlFor={ids.servUnit} className="sr-only">Serving unit</label>
@@ -136,14 +138,14 @@ export function CustomFoodTab() {
             {servUnit !== 'g' && (
               <div className="flex flex-col">
                 <label htmlFor={ids.density} className="sr-only">Density (g/ml)</label>
-                <input id={ids.density} className="form-input" type="number" min={0.01} step={0.01} placeholder={`Density (g/ml)`} {...register('density', { valueAsNumber: true })} />
+                <Input id={ids.density} type="number" min={0.01} step={0.01} placeholder={`Density (g/ml)`} {...register('density', { valueAsNumber: true })} />
               </div>
             )}
             {labelPer100 && (
               <div className="flex flex-wrap items-center gap-3">
-                <button className="btn btn-secondary btn-sm" type="button" onClick={applyConverterValues}>
+                <Button className="btn-secondary btn-sm" type="button" onClick={applyConverterValues}>
                   Apply ↓
-                </button>
+                </Button>
                 <div className="text-xs text-text-muted dark:text-text-muted-dark">
                   <b>Per 100g:</b> {labelPer100.kcal.toFixed(0)}kcal, {labelPer100.fat.toFixed(1)}F, {labelPer100.carb.toFixed(1)}C, {labelPer100.protein.toFixed(1)}P
                 </div>
@@ -156,35 +158,35 @@ export function CustomFoodTab() {
         <h4 className="font-medium text-sm text-text dark:text-text-light">Create Food (values per 100g)</h4>
         <div>
           <label htmlFor={ids.description} className="sr-only">Description</label>
-          <input id={ids.description} className="form-input" placeholder="Description (e.g., Pop-Tarts)" {...register('description', { required: 'Description is required' })} />
+          <Input id={ids.description} placeholder="Description (e.g., Pop-Tarts)" {...register('description', { required: 'Description is required' })} />
           {errors.description && <p className="text-xs text-brand-danger mt-1">{errors.description.message}</p>}
         </div>
         <div>
           <label htmlFor={ids.brand} className="sr-only">Brand / store</label>
-          <input id={ids.brand} className="form-input" placeholder="Brand / store (optional)" {...register('brand_owner')} />
+          <Input id={ids.brand} placeholder="Brand / store (optional)" {...register('brand_owner')} />
         </div>
         <div className="grid grid-cols-2 gap-2">
           <div className="flex flex-col">
             <label htmlFor={ids.kcal} className="sr-only">kcal</label>
-            <input id={ids.kcal} className="form-input" type="number" step="0.01" placeholder="kcal" {...register('kcal_per_100g', { required: true, valueAsNumber: true, min: 0 })} />
+            <Input id={ids.kcal} type="number" step={0.01} placeholder="kcal" {...register('kcal_per_100g', { required: true, valueAsNumber: true, min: 0 })} />
           </div>
           <div className="flex flex-col">
             <label htmlFor={ids.protein} className="sr-only">protein g</label>
-            <input id={ids.protein} className="form-input" type="number" step="0.01" placeholder="protein g" {...register('protein_g_per_100g', { required: true, valueAsNumber: true, min: 0 })} />
+            <Input id={ids.protein} type="number" step={0.01} placeholder="protein g" {...register('protein_g_per_100g', { required: true, valueAsNumber: true, min: 0 })} />
           </div>
           <div className="flex flex-col">
             <label htmlFor={ids.fat} className="sr-only">fat g</label>
-            <input id={ids.fat} className="form-input" type="number" step="0.01" placeholder="fat g" {...register('fat_g_per_100g', { required: true, valueAsNumber: true, min: 0 })} />
+            <Input id={ids.fat} type="number" step={0.01} placeholder="fat g" {...register('fat_g_per_100g', { required: true, valueAsNumber: true, min: 0 })} />
           </div>
           <div className="flex flex-col">
             <label htmlFor={ids.carb} className="sr-only">carb g</label>
-            <input id={ids.carb} className="form-input" type="number" step="0.01" placeholder="carb g" {...register('carb_g_per_100g', { required: true, valueAsNumber: true, min: 0 })} />
+            <Input id={ids.carb} type="number" step={0.01} placeholder="carb g" {...register('carb_g_per_100g', { required: true, valueAsNumber: true, min: 0 })} />
           </div>
         </div>
         <div className="flex justify-end pt-2">
-          <button type="submit" className="btn btn-primary" disabled={isCreatingFood || !isValid}>
+          <Button type="submit" className="btn-primary" disabled={isCreatingFood || !isValid}>
             {isCreatingFood ? 'Creating...' : 'Create Food'}
-          </button>
+          </Button>
         </div>
       </div>
     </form>

--- a/web/src/components/control-panel/ExportTab.tsx
+++ b/web/src/components/control-panel/ExportTab.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import toast from 'react-hot-toast';
 import * as api from "../../api";
+import { Button } from "../ui/Button";
+import { Input } from "../ui/Input";
 
 export function ExportTab() {
   const [exportStart, setExportStart] = useState<string>(new Date().toISOString().slice(0, 10));
@@ -25,15 +27,15 @@ export function ExportTab() {
     <div className="space-y-2">
       <div className="flex items-center gap-2">
         <label htmlFor={ids.from} className="text-sm">From:</label>
-        <input id={ids.from} className="form-input" type="date" value={exportStart} onChange={e=>setExportStart(e.target.value)} />
+        <Input id={ids.from} type="date" value={exportStart} onChange={e=>setExportStart(e.target.value)} />
       </div>
       <div className="flex items-center gap-2">
         <label htmlFor={ids.to} className="text-sm">To:</label>
-        <input id={ids.to} className="form-input" type="date" value={exportEnd} onChange={e=>setExportEnd(e.target.value)} />
+        <Input id={ids.to} type="date" value={exportEnd} onChange={e=>setExportEnd(e.target.value)} />
       </div>
-      <button disabled={invalidRange || isExporting} className="btn btn-secondary w-full" onClick={handleExport}>
+      <Button disabled={invalidRange || isExporting} className="btn-secondary w-full" onClick={handleExport}>
         {isExporting ? 'Downloading...' : 'Download CSV'}
-      </button>
+      </Button>
     </div>
   );
 }

--- a/web/src/components/control-panel/GoalsTab.tsx
+++ b/web/src/components/control-panel/GoalsTab.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import toast from 'react-hot-toast';
 import { useStore } from "../../store";
+import { Button } from "../ui/Button";
+import { Input } from "../ui/Input";
 
 export function GoalsTab() {
   const { goals, setGoals } = useStore();
@@ -40,18 +42,18 @@ export function GoalsTab() {
       <div className="grid grid-cols-2 gap-2">
         <div className="flex flex-col">
           <label htmlFor={ids.fat} className="sr-only">Fat grams</label>
-          <input id={ids.fat} className="form-input" type="number" step="0.1" placeholder="Fat g" value={goalInput.fat} onChange={e=>setGoalInput({ ...goalInput, fat: e.target.value })} />
+          <Input id={ids.fat} type="number" step="0.1" placeholder="Fat g" value={goalInput.fat} onChange={e=>setGoalInput({ ...goalInput, fat: e.target.value })} />
         </div>
         <div className="flex flex-col">
           <label htmlFor={ids.carb} className="sr-only">Carb grams</label>
-          <input id={ids.carb} className="form-input" type="number" step="0.1" placeholder="Carb g" value={goalInput.carb} onChange={e=>setGoalInput({ ...goalInput, carb: e.target.value })} />
+          <Input id={ids.carb} type="number" step="0.1" placeholder="Carb g" value={goalInput.carb} onChange={e=>setGoalInput({ ...goalInput, carb: e.target.value })} />
         </div>
         <div className="flex flex-col">
           <label htmlFor={ids.protein} className="sr-only">Protein grams</label>
-          <input id={ids.protein} className="form-input" type="number" step="0.1" placeholder="Protein g" value={goalInput.protein} onChange={e=>setGoalInput({ ...goalInput, protein: e.target.value })} />
+          <Input id={ids.protein} type="number" step="0.1" placeholder="Protein g" value={goalInput.protein} onChange={e=>setGoalInput({ ...goalInput, protein: e.target.value })} />
         </div>
       </div>
-      <button className="btn btn-secondary w-full" onClick={handleSaveGoals}>Save Goals</button>
+      <Button className="btn-secondary w-full" onClick={handleSaveGoals}>Save Goals</Button>
     </div>
   );
 }

--- a/web/src/components/control-panel/PresetsTab.tsx
+++ b/web/src/components/control-panel/PresetsTab.tsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 import toast from 'react-hot-toast';
 import { useStore } from "../../store";
 import * as api from "../../api";
+import { Button } from "../ui/Button";
+import { Input } from "../ui/Input";
 
 export function PresetsTab() {
   const { date, presets, refreshPresets, applyPreset } = useStore();
@@ -30,10 +32,10 @@ export function PresetsTab() {
     <div className="space-y-4">
       <div className="space-y-2">
         <label htmlFor={idPreset} className="sr-only">Preset name</label>
-        <input id={idPreset} className="form-input" placeholder="Save current meal as..." value={newPresetName} onChange={(e) => setNewPresetName(e.target.value)} />
-        <button className="btn btn-secondary w-full" onClick={handleSavePreset} disabled={isSavingPreset || !currentMeal?.entries?.length || !newPresetName.trim()}>
+        <Input id={idPreset} placeholder="Save current meal as..." value={newPresetName} onChange={(e) => setNewPresetName(e.target.value)} />
+        <Button className="btn-secondary w-full" onClick={handleSavePreset} disabled={isSavingPreset || !currentMeal?.entries?.length || !newPresetName.trim()}>
           {isSavingPreset ? 'Saving...' : 'Save Preset'}
-        </button>
+        </Button>
       </div>
       <div className="max-h-64 overflow-auto">
         <table className="w-full text-sm">
@@ -44,12 +46,12 @@ export function PresetsTab() {
                 <td className="p-2">{p.name} ({p.item_count})</td>
                 <td className="p-2 text-right">
                   <div className="flex gap-1 justify-end">
-                    <button className="btn btn-ghost btn-sm" onClick={() => applyPreset(p.id)}>Apply</button>
-                    <button className="btn btn-ghost btn-sm text-brand-danger hover:bg-brand-danger/10 dark:hover:bg-brand-danger/30" onClick={async () => {
+                    <Button className="btn-ghost btn-sm" onClick={() => applyPreset(p.id)}>Apply</Button>
+                    <Button className="btn-ghost btn-sm text-brand-danger hover:bg-brand-danger/10 dark:hover:bg-brand-danger/30" onClick={async () => {
                       if (!confirm(`Delete preset \"${p.name}\"?`)) return;
                       await api.deletePreset(p.id);
                       await refreshPresets();
-                    }}>Delete</button>
+                    }}>Delete</Button>
                   </div>
                 </td>
               </tr>

--- a/web/src/components/control-panel/SearchTab.tsx
+++ b/web/src/components/control-panel/SearchTab.tsx
@@ -4,6 +4,8 @@ import { useStore } from "../../store";
 import * as api from "../../api";
 import { DATA_TYPE_OPTIONS } from "../../types";
 import type { DataTypeOpt, SimpleFood } from "../../types";
+import { Button } from "../ui/Button";
+import { Input } from "../ui/Input";
 
 export function SearchTab() {
   const { mealName, allMyFoods, setAllMyFoods, addFood } = useStore();
@@ -80,7 +82,7 @@ export function SearchTab() {
   return (
     <>
       <label htmlFor={idQuery} className="sr-only">Search foods</label>
-      <input id={idQuery} className="form-input" placeholder="Search foods…" value={query} onChange={e => setQuery(e.target.value)} />
+      <Input id={idQuery} placeholder="Search foods…" value={query} onChange={e => setQuery(e.target.value)} />
       <div className="flex items-center gap-2">
         <div className="flex flex-col">
           <label htmlFor={idTypeFilter} className="text-sm">Data type</label>
@@ -95,7 +97,7 @@ export function SearchTab() {
           </select>
         </div>
         <div className="flex items-center gap-2 text-sm text-text dark:text-text-light whitespace-nowrap">
-          <input
+          <Input
             id={idUnbranded}
             type="checkbox"
             className="rounded text-brand-primary focus:ring-brand-primary"
@@ -116,12 +118,12 @@ export function SearchTab() {
                 onClick={() => setSelected(f.fdcId)}
               >
                 <div className="font-medium truncate text-sm">{f.description}</div>
-                <button
-                  className="btn btn-ghost btn-sm text-brand-danger hover:bg-brand-danger/10 dark:hover:bg-brand-danger/30"
+                <Button
+                  className="btn-ghost btn-sm text-brand-danger hover:bg-brand-danger/10 dark:hover:bg-brand-danger/30"
                   title="Delete custom food"
                   aria-label="Delete custom food"
                   onClick={(e) => { e.stopPropagation(); handleDeleteCustomFood(f.fdcId); }}
-                >🗑️</button>
+                >🗑️</Button>
               </li>
             ))}
           </ul>
@@ -145,10 +147,10 @@ export function SearchTab() {
       </div>
       <div className="flex items-center gap-2">
         <label htmlFor={idGrams} className="text-sm">Grams</label>
-        <input id={idGrams} className="form-input w-24" type="number" min={1} step={1} value={grams} onChange={e => setGrams(parseFloat(e.target.value))} />
-        <button className="btn btn-primary w-full" onClick={handleAddSelectedFood} disabled={!selected || isAddingFood}>
+        <Input id={idGrams} className="w-24" type="number" min={1} step={1} value={grams} onChange={e => setGrams(parseFloat(e.target.value))} />
+        <Button className="btn-primary w-full" onClick={handleAddSelectedFood} disabled={!selected || isAddingFood}>
           {isAddingFood ? 'Adding…' : `Add to ${mealName}`}
-        </button>
+        </Button>
       </div>
     </>
   );

--- a/web/src/components/ui/Button.tsx
+++ b/web/src/components/ui/Button.tsx
@@ -1,0 +1,12 @@
+import { forwardRef } from "react";
+import type { ButtonHTMLAttributes } from "react";
+
+export const Button = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLButtonElement>>(
+  ({ className = "", ...props }, ref) => (
+    <button ref={ref} className={`btn ${className}`} {...props} />
+  )
+);
+
+Button.displayName = "Button";
+
+export default Button;

--- a/web/src/components/ui/Input.tsx
+++ b/web/src/components/ui/Input.tsx
@@ -1,0 +1,12 @@
+import { forwardRef } from "react";
+import type { InputHTMLAttributes } from "react";
+
+export const Input = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>>(
+  ({ className = "", type = "text", ...props }, ref) => (
+    <input ref={ref} type={type} className={`${type === 'checkbox' || type === 'radio' ? '' : 'form-input'} ${className}`} {...props} />
+  )
+);
+
+Input.displayName = "Input";
+
+export default Input;

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -5,6 +5,7 @@ import { getHistory } from "../api";
 import type { HistoryDay } from "../types";
 import { LoadingSpinner } from "../components/LoadingSpinner";
 import { useStore } from "../store";
+import { Button } from "../components/ui/Button";
 
 const palettes = {
     light: {
@@ -68,13 +69,13 @@ export function DashboardPage() {
         <div className="space-y-8">
             <div className="flex gap-2">
                 {[7, 30, 90].map(opt => (
-                    <button
+                    <Button
                         key={opt}
                         onClick={() => setDays(opt)}
-                        className={`px-3 py-1 rounded ${days === opt ? 'bg-brand-primary text-text-light' : 'bg-surface-light dark:bg-border-dark'}`}
+                        className={`btn-ghost px-3 py-1 rounded ${days === opt ? 'bg-brand-primary text-text-light' : 'bg-surface-light dark:bg-border-dark'}`}
                     >
                         Last {opt} Days
-                    </button>
+                    </Button>
                 ))}
             </div>
             <div className="card">


### PR DESCRIPTION
## Summary
- create reusable `Button` and `Input` components that forward refs and include shared classes
- refactor app, control panel tabs, daily log, summary, and theme toggle to use the new components
- replace all direct `<button>`/`<input>` usage for consistent styling

## Testing
- `npm --prefix web run lint` *(fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './config' is not defined by "exports" in eslint package)*
- `npm --prefix web run build`


------
https://chatgpt.com/codex/tasks/task_e_68996e743b588327b63e68cdbe8e164b