### PR TITLE
fix: support running server package standalone

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -3,9 +3,14 @@ from fastapi.middleware.cors import CORSMiddleware
 from sqlmodel import SQLModel, Session, select
 from sqlalchemy import text
 
-from .db import get_session, get_engine
-from .models import Meal, Food
-from .routers import foods, meals, presets
+try:
+    from .db import get_session, get_engine
+    from .models import Meal, Food
+    from .routers import foods, meals, presets
+except ImportError:  # pragma: no cover
+    from db import get_session, get_engine
+    from models import Meal, Food
+    from routers import foods, meals, presets
 
 app = FastAPI(title="Macro Tracker API")
 app.add_middleware(

--- a/server/routers/foods.py
+++ b/server/routers/foods.py
@@ -6,9 +6,14 @@ from sqlmodel import Session, select, delete
 from sqlalchemy import func
 from pydantic import BaseModel, field_validator
 
-from ..db import get_session
-from ..models import Food, FoodEntry, Favorite
-from ..utils import fetch_food_detail, ensure_food_cached, USDA_KEY, USDA_BASE
+try:
+    from ..db import get_session
+    from ..models import Food, FoodEntry, Favorite
+    from ..utils import fetch_food_detail, ensure_food_cached, USDA_KEY, USDA_BASE
+except ImportError:  # pragma: no cover
+    from db import get_session
+    from models import Food, FoodEntry, Favorite
+    from utils import fetch_food_detail, ensure_food_cached, USDA_KEY, USDA_BASE
 
 router = APIRouter()
 

--- a/server/routers/meals.py
+++ b/server/routers/meals.py
@@ -7,9 +7,14 @@ from sqlmodel import Session, select
 from sqlalchemy import func, delete
 from pydantic import BaseModel
 
-from ..db import get_session
-from ..models import Meal, FoodEntry, Food
-from ..utils import get_or_create_meal, ensure_food_cached
+try:
+    from ..db import get_session
+    from ..models import Meal, FoodEntry, Food
+    from ..utils import get_or_create_meal, ensure_food_cached
+except ImportError:  # pragma: no cover
+    from db import get_session
+    from models import Meal, FoodEntry, Food
+    from utils import get_or_create_meal, ensure_food_cached
 
 router = APIRouter()
 

--- a/server/routers/presets.py
+++ b/server/routers/presets.py
@@ -4,9 +4,14 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Session, select, delete
 from pydantic import BaseModel
 
-from ..db import get_session
-from ..models import Preset, PresetItem, Food, Meal, FoodEntry
-from ..utils import get_or_create_meal, ensure_food_cached
+try:
+    from ..db import get_session
+    from ..models import Preset, PresetItem, Food, Meal, FoodEntry
+    from ..utils import get_or_create_meal, ensure_food_cached
+except ImportError:  # pragma: no cover
+    from db import get_session
+    from models import Preset, PresetItem, Food, Meal, FoodEntry
+    from utils import get_or_create_meal, ensure_food_cached
 
 router = APIRouter()
 

--- a/server/utils.py
+++ b/server/utils.py
@@ -7,7 +7,10 @@ from fastapi import HTTPException
 from sqlmodel import Session, select
 from sqlalchemy import func
 
-from .models import Food, Meal
+try:
+    from .models import Food, Meal
+except ImportError:  # pragma: no cover
+    from models import Food, Meal
 
 USDA_BASE = "https://api.nal.usda.gov/fdc/v1"
 from dotenv import load_dotenv, find_dotenv


### PR DESCRIPTION
## Summary
- allow server modules to fall back to absolute imports when run standalone
- ensure utilities and routers can import modules with or without package context

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a37da9f2483279abfa6273eda7fb8