### PR TITLE
fix: robust imports in server entry point

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -1,1 +1,24 @@
-from app import app
+"""Expose the FastAPI ``app`` instance for ASGI servers.
+
+This module allows the server package to be executed in a couple of ways:
+
+* ``uvicorn server.main:app`` when the ``server`` package is on the import
+  path.
+* ``python server/main.py`` when running from within the ``server`` directory.
+
+Previously, ``main.py`` unconditionally imported ``app`` using an absolute
+import.  This worked only when executing the file directly from the ``server``
+directory but failed when the module was imported as part of the ``server``
+package (e.g. ``uvicorn server.main:app``).  That scenario raised a
+``ModuleNotFoundError`` because the top-level ``app`` module could not be
+found.
+
+To support both use cases we try a package-relative import first and fall back
+to the absolute import when ``main.py`` is executed as a script.
+"""
+
+try:  # pragma: no cover - exercised in integration but trivial to test
+    from .app import app
+except ImportError:  # pragma: no cover
+    from app import app  # type: ignore
+


### PR DESCRIPTION
## Summary
- allow server/main.py to be imported as `server.main` or executed directly
- document entry point behavior

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a3aafaebc8327b4f38b1856c0378a