### PR TITLE
Add history API for dashboard

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -6,11 +6,11 @@ from sqlalchemy import text
 try:
     from .db import get_session, get_engine
     from .models import Meal, Food
-    from .routers import foods, meals, presets
+    from .routers import foods, meals, presets, history
 except ImportError:  # pragma: no cover
     from db import get_session, get_engine
     from models import Meal, Food
-    from routers import foods, meals, presets
+    from routers import foods, meals, presets, history
 
 app = FastAPI(title="Macro Tracker API")
 app.add_middleware(
@@ -24,6 +24,7 @@ app.add_middleware(
 app.include_router(foods.router)
 app.include_router(meals.router)
 app.include_router(presets.router)
+app.include_router(history.router)
 
 def ensure_meal_sort_order_column(session: Session):
     tbl = session.exec(text("SELECT name FROM sqlite_master WHERE type='table' AND name='meal'")).first()

--- a/server/routers/__init__.py
+++ b/server/routers/__init__.py
@@ -1,2 +1,2 @@
-from . import foods, meals, presets
-__all__ = ["foods", "meals", "presets"]
+from . import foods, meals, presets, history
+__all__ = ["foods", "meals", "presets", "history"]

--- a/server/routers/history.py
+++ b/server/routers/history.py
@@ -1,0 +1,91 @@
+from datetime import date, timedelta
+from typing import Dict
+
+from fastapi import APIRouter, Depends
+from sqlmodel import Session, select
+
+try:
+    from ..db import get_session
+    from ..models import Meal, FoodEntry, Food, BodyWeight
+except ImportError:  # pragma: no cover
+    from db import get_session
+    from models import Meal, FoodEntry, Food, BodyWeight
+
+router = APIRouter()
+
+
+def _scaled_from_food(f: Food, grams: float):
+    factor = (grams or 0) / 100.0
+    return (
+        (f.kcal_per_100g or 0) * factor,
+        (f.protein_g_per_100g or 0) * factor,
+        (f.carb_g_per_100g or 0) * factor,
+        (f.fat_g_per_100g or 0) * factor,
+    )
+
+
+@router.get("/api/history")
+def get_history(start_date: str, end_date: str, session: Session = Depends(get_session)):
+    meals = session.exec(
+        select(Meal).where(Meal.date >= start_date, Meal.date <= end_date)
+    ).all()
+    meal_map = {m.id: m for m in meals}
+    meal_ids = list(meal_map.keys())
+
+    entries = []
+    foods: Dict[int, Food] = {}
+    if meal_ids:
+        entries = session.exec(
+            select(FoodEntry).where(FoodEntry.meal_id.in_(meal_ids))
+        ).all()
+        fdc_ids = {e.fdc_id for e in entries}
+        if fdc_ids:
+            foods = {
+                f.fdc_id: f
+                for f in session.exec(select(Food).where(Food.fdc_id.in_(fdc_ids))).all()
+            }
+
+    weights = session.exec(
+        select(BodyWeight).where(
+            BodyWeight.date >= start_date, BodyWeight.date <= end_date
+        )
+    ).all()
+    weight_map = {w.date: w.weight for w in weights}
+
+    totals: Dict[str, Dict[str, float]] = {}
+    for e in entries:
+        meal = meal_map.get(e.meal_id)
+        if not meal:
+            continue
+        day = meal.date
+        if day not in totals:
+            totals[day] = {"kcal": 0.0, "protein": 0.0, "carb": 0.0, "fat": 0.0}
+        food = foods.get(e.fdc_id)
+        if not food:
+            continue
+        kcal, p, c, fat = _scaled_from_food(food, e.quantity_g)
+        totals[day]["kcal"] += kcal
+        totals[day]["protein"] += p
+        totals[day]["carb"] += c
+        totals[day]["fat"] += fat
+
+    start = date.fromisoformat(start_date)
+    end = date.fromisoformat(end_date)
+    out = []
+    cur = start
+    while cur <= end:
+        day = cur.isoformat()
+        t = totals.get(day, {"kcal": 0.0, "protein": 0.0, "carb": 0.0, "fat": 0.0})
+        out.append(
+            {
+                "date": day,
+                "kcal": round(t["kcal"], 2),
+                "protein": round(t["protein"], 2),
+                "carb": round(t["carb"], 2),
+                "fat": round(t["fat"], 2),
+                "weight": weight_map.get(day),
+            }
+        )
+        cur += timedelta(days=1)
+
+    return out

--- a/server/tests/test_history.py
+++ b/server/tests/test_history.py
@@ -1,0 +1,68 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ['USDA_KEY'] = 'test'
+
+# Allow importing the server modules
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, Session, create_engine
+from sqlalchemy.pool import StaticPool
+
+from server import app, db
+from server.models import Food, Meal, FoodEntry, BodyWeight
+
+
+def get_test_engine():
+    return create_engine(
+        'sqlite://',
+        connect_args={'check_same_thread': False},
+        poolclass=StaticPool,
+    )
+
+
+def override_get_session(engine):
+    def _get_session():
+        with Session(engine) as session:
+            yield session
+    return _get_session
+
+
+def test_history_returns_macros_and_weight():
+    engine = get_test_engine()
+    db.engine = engine
+    app.app.dependency_overrides[db.get_session] = override_get_session(engine)
+
+    with TestClient(app.app) as client:
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as session:
+            food = Food(
+                fdc_id=1,
+                description='Test Food',
+                kcal_per_100g=100,
+                protein_g_per_100g=10,
+                carb_g_per_100g=5,
+                fat_g_per_100g=2,
+            )
+            session.add(food)
+            meal1 = Meal(date='2024-01-01', name='Meal 1', sort_order=1)
+            meal2 = Meal(date='2024-01-02', name='Meal 1', sort_order=1)
+            session.add_all([meal1, meal2])
+            session.commit()
+            e1 = FoodEntry(meal_id=meal1.id, fdc_id=1, quantity_g=100)
+            e2 = FoodEntry(meal_id=meal2.id, fdc_id=1, quantity_g=200)
+            session.add_all([e1, e2])
+            w1 = BodyWeight(date='2024-01-01', weight=180)
+            w2 = BodyWeight(date='2024-01-02', weight=181)
+            session.add_all([w1, w2])
+            session.commit()
+
+        resp = client.get('/api/history', params={'start_date': '2024-01-01', 'end_date': '2024-01-02'})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data == [
+            {'date': '2024-01-01', 'kcal': 100.0, 'protein': 10.0, 'carb': 5.0, 'fat': 2.0, 'weight': 180.0},
+            {'date': '2024-01-02', 'kcal': 200.0, 'protein': 20.0, 'carb': 10.0, 'fat': 4.0, 'weight': 181.0},
+        ]


### PR DESCRIPTION
## Summary
- add FastAPI router that returns daily macro and weight history
- register history router with the application
- test history endpoint

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a3c4bcd3c8327a0b6142075f0c3a9