### PR TITLE
Use platformdirs for DB path and migrate old food log

### DIFF
--- a/server/db.py
+++ b/server/db.py
@@ -1,6 +1,19 @@
+from pathlib import Path
+import shutil
+
+from platformdirs import user_data_dir
 from sqlmodel import Session, create_engine
 
-DATABASE_URL = "sqlite:///./foodlog.db"
+
+data_dir = Path(user_data_dir("MacroTracker", "MacroTracker"))
+data_dir.mkdir(parents=True, exist_ok=True)
+
+old_db_path = Path("foodlog.db")
+new_db_path = data_dir / "foodlog.db"
+if old_db_path.exists() and not new_db_path.exists():
+    shutil.move(str(old_db_path), str(new_db_path))
+
+DATABASE_URL = f"sqlite:///{new_db_path}"
 engine = create_engine(DATABASE_URL, echo=False)
 
 def get_engine():

--- a/server/migrate_db.py
+++ b/server/migrate_db.py
@@ -1,0 +1,26 @@
+"""Migration script to move existing foodlog.db to the new data directory."""
+
+from pathlib import Path
+import shutil
+
+from platformdirs import user_data_dir
+
+
+def migrate_foodlog_db():
+    """Move foodlog.db from the current directory to the platform-specific data directory."""
+    data_dir = Path(user_data_dir("MacroTracker", "MacroTracker"))
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    old_db_path = Path("foodlog.db")
+    new_db_path = data_dir / "foodlog.db"
+
+    if old_db_path.exists() and not new_db_path.exists():
+        shutil.move(str(old_db_path), str(new_db_path))
+        print(f"Moved {old_db_path} to {new_db_path}")
+    else:
+        print("No migration needed")
+
+
+if __name__ == "__main__":
+    migrate_foodlog_db()
+


### PR DESCRIPTION
## Summary
- Use platformdirs to store SQLite database in a user-specific data directory
- Provide script to migrate existing foodlog.db into the new location

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a409583048327923d6c75ba646482