### PR TITLE
Add weight API endpoints

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -6,11 +6,11 @@ from sqlalchemy import text
 try:
     from .db import get_session, get_engine
     from .models import Meal, Food
-    from .routers import foods, meals, presets, history
+    from .routers import foods, meals, presets, history, weight
 except ImportError:  # pragma: no cover
     from db import get_session, get_engine
     from models import Meal, Food
-    from routers import foods, meals, presets, history
+    from routers import foods, meals, presets, history, weight
 
 app = FastAPI(title="Macro Tracker API")
 app.add_middleware(
@@ -25,6 +25,7 @@ app.include_router(foods.router)
 app.include_router(meals.router)
 app.include_router(presets.router)
 app.include_router(history.router)
+app.include_router(weight.router)
 
 def ensure_meal_sort_order_column(session: Session):
     tbl = session.exec(text("SELECT name FROM sqlite_master WHERE type='table' AND name='meal'")).first()

--- a/server/routers/__init__.py
+++ b/server/routers/__init__.py
@@ -1,2 +1,2 @@
-from . import foods, meals, presets, history
-__all__ = ["foods", "meals", "presets", "history"]
+from . import foods, meals, presets, history, weight
+__all__ = ["foods", "meals", "presets", "history", "weight"]

--- a/server/routers/weight.py
+++ b/server/routers/weight.py
@@ -1,0 +1,39 @@
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlmodel import Session
+
+try:
+    from ..db import get_session
+    from ..models import BodyWeight
+except ImportError:  # pragma: no cover
+    from db import get_session
+    from models import BodyWeight
+
+router = APIRouter()
+
+
+@router.get("/api/weight/{date}", response_model=BodyWeight)
+def get_weight(date: str, session: Session = Depends(get_session)):
+    weight = session.get(BodyWeight, date)
+    if not weight:
+        raise HTTPException(status_code=404, detail="Weight not found")
+    return weight
+
+
+class WeightPayload(BaseModel):
+    weight: float
+
+
+@router.put("/api/weight/{date}", response_model=BodyWeight)
+def set_weight(date: str, payload: WeightPayload, session: Session = Depends(get_session)):
+    weight_entry = session.get(BodyWeight, date)
+    if weight_entry:
+        weight_entry.weight = payload.weight
+    else:
+        weight_entry = BodyWeight(date=date, weight=payload.weight)
+    session.add(weight_entry)
+    session.commit()
+    session.refresh(weight_entry)
+    return weight_entry

--- a/server/tests/test_weight.py
+++ b/server/tests/test_weight.py
@@ -1,0 +1,45 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ['USDA_KEY'] = 'test'
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, Session, create_engine
+from sqlalchemy.pool import StaticPool
+
+from server import app, db
+
+
+def get_test_engine():
+    return create_engine(
+        'sqlite://',
+        connect_args={'check_same_thread': False},
+        poolclass=StaticPool,
+    )
+
+
+def override_get_session(engine):
+    def _get_session():
+        with Session(engine) as session:
+            yield session
+    return _get_session
+
+
+def test_set_and_get_weight():
+    engine = get_test_engine()
+    db.engine = engine
+    app.app.dependency_overrides[db.get_session] = override_get_session(engine)
+
+    with TestClient(app.app) as client:
+        SQLModel.metadata.create_all(engine)
+
+        resp = client.put("/api/weight/2024-01-01", json={"weight": 180})
+        assert resp.status_code == 200
+        assert resp.json()["weight"] == 180
+
+        resp2 = client.get("/api/weight/2024-01-01")
+        assert resp2.status_code == 200
+        assert resp2.json()["weight"] == 180


### PR DESCRIPTION
## Summary
- add GET and PUT /api/weight/{date} endpoints to persist daily body weight
- include weight router in FastAPI app and router exports
- test weight endpoints

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a46ae4bb883279ffa4337403980a0