### PR TITLE
Fix CSV export to download CSV file properly

### DIFF
--- a/web/src/components/control-panel/ExportTab.tsx
+++ b/web/src/components/control-panel/ExportTab.tsx
@@ -13,7 +13,18 @@ export function ExportTab() {
   async function handleExport() {
     setIsExporting(true);
     try {
-      await api.exportCSV(exportStart, exportEnd);
+      const response = await api.exportCSV(exportStart, exportEnd);
+      const blob = new Blob([response.data], { type: 'text/csv' });
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download =
+        response.headers['content-disposition']?.split('filename=')[1]?.replace(/"/g, '') ||
+        `macro_export_${exportStart}_to_${exportEnd}.csv`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      window.URL.revokeObjectURL(url);
     } catch (err: any) {
       toast.error("Export failed. Please try again.");
     } finally {


### PR DESCRIPTION
## Summary
- ensure Export tab saves server CSV as a downloadable file

## Testing
- `pytest -q`
- `npm run lint` *(fails: Package subpath './config' not defined by "exports" in eslint package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a4cf19e4483279cd555f5984cff11