### PR TITLE
Add USDA API key onboarding and configuration

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -6,11 +6,11 @@ from sqlalchemy import text
 try:
     from .db import get_session, get_engine
     from .models import Meal, Food
-    from .routers import foods, meals, presets, history, weight
+    from .routers import foods, meals, presets, history, weight, config
 except ImportError:  # pragma: no cover
     from db import get_session, get_engine
     from models import Meal, Food
-    from routers import foods, meals, presets, history, weight
+    from routers import foods, meals, presets, history, weight, config
 
 app = FastAPI(title="Macro Tracker API")
 app.add_middleware(
@@ -26,6 +26,7 @@ app.include_router(meals.router)
 app.include_router(presets.router)
 app.include_router(history.router)
 app.include_router(weight.router)
+app.include_router(config.router)
 
 def ensure_meal_sort_order_column(session: Session):
     tbl = session.exec(text("SELECT name FROM sqlite_master WHERE type='table' AND name='meal'")).first()

--- a/server/routers/__init__.py
+++ b/server/routers/__init__.py
@@ -1,2 +1,2 @@
-from . import foods, meals, presets, history, weight
-__all__ = ["foods", "meals", "presets", "history", "weight"]
+from . import foods, meals, presets, history, weight, config
+__all__ = ["foods", "meals", "presets", "history", "weight", "config"]

--- a/server/routers/config.py
+++ b/server/routers/config.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+try:
+    from .. import utils
+except ImportError:  # pragma: no cover
+    import utils
+
+router = APIRouter()
+
+@router.get("/api/config/usda-key")
+def get_usda_key():
+    return {"key": utils.USDA_KEY}
+
+class KeyPayload(BaseModel):
+    key: str
+
+@router.post("/api/config/usda-key")
+def set_usda_key(payload: KeyPayload):
+    if not payload.key:
+        raise HTTPException(status_code=400, detail="Key required")
+    utils.update_usda_key(payload.key)
+    return {"ok": True}

--- a/server/tests/test_usda_key_endpoint.py
+++ b/server/tests/test_usda_key_endpoint.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import json
+from pathlib import Path
+
+# ensure config path temporary
+
+def test_usda_key_update(tmp_path, monkeypatch):
+    monkeypatch.setenv('USDA_CONFIG_PATH', str(tmp_path / 'cfg.json'))
+    monkeypatch.setenv('USDA_KEY', 'envkey')
+    sys.path.append(str(Path(__file__).resolve().parents[2]))
+    from importlib import reload
+    import server.utils as utils
+    reload(utils)
+    import server.routers.foods as foods
+    reload(foods)
+    import server.app as app
+    reload(app)
+    from fastapi.testclient import TestClient
+    from server import db
+    from sqlmodel import SQLModel, Session, create_engine
+    from sqlalchemy.pool import StaticPool
+
+    def get_test_engine():
+        return create_engine('sqlite://', connect_args={'check_same_thread': False}, poolclass=StaticPool)
+
+    def override_get_session(engine):
+        def _get_session():
+            with Session(engine) as session:
+                yield session
+        return _get_session
+
+    engine = get_test_engine()
+    db.engine = engine
+    app.app.dependency_overrides[db.get_session] = override_get_session(engine)
+
+    with TestClient(app.app) as client:
+        SQLModel.metadata.create_all(engine)
+        # initial key from env
+        resp = client.get('/api/config/usda-key')
+        assert resp.status_code == 200
+        assert resp.json()['key'] == 'envkey'
+        # update key
+        resp = client.post('/api/config/usda-key', json={'key': 'newkey'})
+        assert resp.status_code == 200
+        assert resp.json()['ok'] is True
+        # verify
+        resp = client.get('/api/config/usda-key')
+        assert resp.json()['key'] == 'newkey'
+        cfg = json.load(open(tmp_path / 'cfg.json'))
+        assert cfg['usda_key'] == 'newkey'

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,13 +6,22 @@ import { DashboardPage } from "./pages/DashboardPage";
 import { NotFoundPage } from "./pages/NotFoundPage";
 import { Layout } from "./components/Layout";
 import { LoadingSpinner } from "./components/LoadingSpinner";
+import { UsdaKeyDialog } from "./components/UsdaKeyDialog";
+import * as api from "./api";
 
 export default function App() {
-  const init = useStore(state => state.init);
+  const init = useStore((state) => state.init);
   const [loading, setLoading] = useState(true);
+  const [needsKey, setNeedsKey] = useState(false);
 
   useEffect(() => {
-    init().finally(() => setLoading(false));
+    const run = async () => {
+      await init();
+      const key = await api.getUsdaKey();
+      setNeedsKey(!key);
+      setLoading(false);
+    };
+    run();
   }, [init]);
 
   if (loading) {
@@ -23,15 +32,16 @@ export default function App() {
     );
   }
 
-    return (
-      <BrowserRouter>
-        <Layout>
-          <Routes>
-            <Route path="/" element={<TrackerPage />} />
-            <Route path="/dashboard" element={<DashboardPage />} />
-            <Route path="*" element={<NotFoundPage />} />
-          </Routes>
-        </Layout>
-      </BrowserRouter>
-    );
-  }
+  return (
+    <BrowserRouter>
+      {needsKey && <UsdaKeyDialog onSaved={() => setNeedsKey(false)} />}
+      <Layout>
+        <Routes>
+          <Route path="/" element={<TrackerPage />} />
+          <Route path="/dashboard" element={<DashboardPage />} />
+          <Route path="*" element={<NotFoundPage />} />
+        </Routes>
+      </Layout>
+    </BrowserRouter>
+  );
+}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -122,3 +122,14 @@ export async function setWeight(date: string, weight: number) {
   const response = await api.put(`/weight/${date}`, { weight });
   return response.data;
 }
+
+// --- Configuration ---
+export async function getUsdaKey(): Promise<string | null> {
+  const response = await api.get("/config/usda-key");
+  return response.data.key || null;
+}
+
+export async function updateUsdaKey(key: string) {
+  const response = await api.post("/config/usda-key", { key });
+  return response.data;
+}

--- a/web/src/components/UsdaKeyDialog.tsx
+++ b/web/src/components/UsdaKeyDialog.tsx
@@ -1,0 +1,42 @@
+import { useState } from "react";
+import { Button } from "./ui/Button";
+import { Input } from "./ui/Input";
+import * as api from "../api";
+
+interface Props {
+  onSaved: () => void;
+}
+
+export function UsdaKeyDialog({ onSaved }: Props) {
+  const [key, setKey] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const save = async () => {
+    if (!key) return;
+    setSaving(true);
+    try {
+      await api.updateUsdaKey(key);
+      onSaved();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black/50 z-50">
+      <div className="bg-white dark:bg-surface-dark p-6 rounded shadow w-full max-w-sm">
+        <h2 className="text-lg font-semibold mb-2">USDA API Key</h2>
+        <p className="text-sm mb-4">Enter your USDA API key to enable food search.</p>
+        <Input
+          value={key}
+          onChange={(e) => setKey(e.target.value)}
+          className="w-full mb-4"
+          placeholder="API Key"
+        />
+        <div className="text-right">
+          <Button onClick={save} disabled={!key || saving}>Save</Button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add persistent config file and update_usda_key helper for USDA API key
- Expose `/api/config/usda-key` endpoint for reading and updating the key
- Display onboarding dialog in React UI to capture the USDA API key on first run

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a50383b8c8327a8f940b388f86eef