### PR TITLE
feat: make API base URL configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # macro_and_cal_tracker
 Tracking macros and calories in an easy-to-use app
+
+## Environment Variables
+
+The frontend reads `VITE_API_BASE_URL` to know where to send API requests. If this
+variable is not set, the app falls back to `window.location.origin`.
+
+Create `.env` files under the `web/` directory to configure the API location for
+different builds:
+
+```
+# web/.env.development
+VITE_API_BASE_URL=http://localhost:8000
+
+# web/.env.desktop
+VITE_API_BASE_URL=http://localhost:8000
+
+# web/.env.production
+VITE_API_BASE_URL=https://example.com
+```
+
+Production builds use `npm run build` and desktop builds use `npm run build:desktop`.

--- a/web/.env.desktop
+++ b/web/.env.desktop
@@ -1,0 +1,2 @@
+# Base URL of the API for desktop builds
+VITE_API_BASE_URL=http://localhost:8000

--- a/web/.env.development
+++ b/web/.env.development
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:8000

--- a/web/.env.production
+++ b/web/.env.production
@@ -1,0 +1,2 @@
+# Base URL of the API for production builds
+VITE_API_BASE_URL=https://example.com

--- a/web/README.md
+++ b/web/README.md
@@ -1,5 +1,10 @@
 # React + TypeScript + Vite
 
+## Environment Variables
+
+The frontend uses the `VITE_API_BASE_URL` environment variable to determine the
+API host. If unset, requests default to the current window origin.
+
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
 Currently, two official plugins are available:

--- a/web/package.json
+++ b/web/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && vite build --mode production",
+    "build:desktop": "tsc -b && vite build --mode desktop",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,7 +1,9 @@
 import axios from "axios";
 import type { HistoryDay } from "./types";
 
-const api = axios.create({ baseURL: "http://localhost:8000/api" });
+const api = axios.create({
+  baseURL: `${import.meta.env.VITE_API_BASE_URL || window.location.origin}/api`,
+});
 
 // --- Food & Search ---
 export async function searchFoods(query: string, dataType: string) {


### PR DESCRIPTION
## Summary
- allow frontend API client to use configurable base URL via `VITE_API_BASE_URL`
- document and provide `.env` examples for development, production, and desktop builds
- add desktop build script and use mode-specific builds

## Testing
- `npm run lint` *(fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './config' is not defined by "exports" in eslint package.json)*
- `npm run build`
- `npm run build:desktop`


------
https://chatgpt.com/codex/tasks/task_e_689a55cf17908327b1fc5e07c17a9e50