### PR TITLE
Add server tests and CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          pip install fastapi sqlmodel sqlalchemy httpx python-dotenv pytest
+      - name: Run tests
+        run: |
+          pytest

--- a/server/tests/test_entry_crud.py
+++ b/server/tests/test_entry_crud.py
@@ -1,0 +1,76 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ['USDA_KEY'] = 'test'
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, Session, create_engine
+from sqlalchemy.pool import StaticPool
+
+from server import app, db
+from server.models import Food, Meal
+
+
+def get_test_engine():
+    return create_engine(
+        'sqlite://',
+        connect_args={'check_same_thread': False},
+        poolclass=StaticPool,
+    )
+
+
+def override_get_session(engine):
+    def _get_session():
+        with Session(engine) as session:
+            yield session
+    return _get_session
+
+
+def test_entry_crud_flow():
+    engine = get_test_engine()
+    db.engine = engine
+    app.app.dependency_overrides[db.get_session] = override_get_session(engine)
+
+    with TestClient(app.app) as client:
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as session:
+            food = Food(
+                fdc_id=1,
+                description='Test Food',
+                kcal_per_100g=100,
+                protein_g_per_100g=10,
+                carb_g_per_100g=5,
+                fat_g_per_100g=2,
+            )
+            meal = Meal(date='2024-01-01', name='Meal 1', sort_order=1)
+            session.add(food)
+            session.add(meal)
+            session.commit()
+            meal_id = meal.id
+
+        resp = client.post('/api/entries', json={'meal_id': meal_id, 'fdc_id': 1, 'quantity_g': 100})
+        assert resp.status_code == 200
+        entry_id = resp.json()['id']
+        assert resp.json()['quantity_g'] == 100
+
+        resp2 = client.patch(f'/api/entries/{entry_id}', json={'quantity_g': 150})
+        assert resp2.status_code == 200
+        assert resp2.json()['quantity_g'] == 150.0
+
+        resp3 = client.get('/api/days/2024-01-01')
+        assert resp3.status_code == 200
+        data = resp3.json()
+        assert data['entries'][0]['fdc_id'] == 1
+        assert data['entries'][0]['quantity_g'] == 150.0
+        assert data['totals'] == {'kcal': 150.0, 'protein': 15.0, 'carb': 7.5, 'fat': 3.0}
+
+        resp4 = client.delete(f'/api/entries/{entry_id}')
+        assert resp4.status_code == 200
+
+        resp5 = client.get('/api/days/2024-01-01')
+        assert resp5.status_code == 200
+        assert resp5.json()['entries'] == []
+        assert resp5.json()['totals'] == {'kcal': 0.0, 'protein': 0.0, 'carb': 0.0, 'fat': 0.0}

--- a/server/tests/test_meal_creation.py
+++ b/server/tests/test_meal_creation.py
@@ -1,0 +1,50 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ['USDA_KEY'] = 'test'
+
+# Allow importing the server modules
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, Session, create_engine
+from sqlalchemy.pool import StaticPool
+
+from server import app, db
+
+
+def get_test_engine():
+    return create_engine(
+        'sqlite://',
+        connect_args={'check_same_thread': False},
+        poolclass=StaticPool,
+    )
+
+
+def override_get_session(engine):
+    def _get_session():
+        with Session(engine) as session:
+            yield session
+    return _get_session
+
+
+def test_meal_creation_increments_sort_order():
+    engine = get_test_engine()
+    db.engine = engine
+    app.app.dependency_overrides[db.get_session] = override_get_session(engine)
+
+    with TestClient(app.app) as client:
+        SQLModel.metadata.create_all(engine)
+
+        resp1 = client.post('/api/meals', json={'date': '2024-01-01'})
+        assert resp1.status_code == 200
+        data1 = resp1.json()
+        assert data1['sort_order'] == 1
+        assert data1['name'] == 'Meal 1'
+
+        resp2 = client.post('/api/meals', json={'date': '2024-01-01'})
+        assert resp2.status_code == 200
+        data2 = resp2.json()
+        assert data2['sort_order'] == 2
+        assert data2['name'] == 'Meal 2'

--- a/server/tests/test_presets.py
+++ b/server/tests/test_presets.py
@@ -1,0 +1,68 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ['USDA_KEY'] = 'test'
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, Session, create_engine
+from sqlalchemy.pool import StaticPool
+
+from server import app, db
+from server.models import Food
+
+
+def get_test_engine():
+    return create_engine(
+        'sqlite://',
+        connect_args={'check_same_thread': False},
+        poolclass=StaticPool,
+    )
+
+
+def override_get_session(engine):
+    def _get_session():
+        with Session(engine) as session:
+            yield session
+    return _get_session
+
+
+def test_preset_create_and_apply():
+    engine = get_test_engine()
+    db.engine = engine
+    app.app.dependency_overrides[db.get_session] = override_get_session(engine)
+
+    with TestClient(app.app) as client:
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as session:
+            session.add(Food(
+                fdc_id=1,
+                description='Food 1',
+                kcal_per_100g=100,
+                protein_g_per_100g=10,
+                carb_g_per_100g=5,
+                fat_g_per_100g=2,
+            ))
+            session.commit()
+
+        resp = client.post('/api/presets', json={'name': 'Preset1', 'items': [{'fdc_id': 1, 'grams': 50}]})
+        assert resp.status_code == 200
+        preset_id = resp.json()['id']
+
+        resp_list = client.get('/api/presets')
+        assert resp_list.status_code == 200
+        assert resp_list.json()['items'][0]['item_count'] == 1
+
+        resp_detail = client.get(f'/api/presets/{preset_id}')
+        assert resp_detail.status_code == 200
+        assert resp_detail.json()['items'][0]['fdc_id'] == 1
+
+        resp_apply = client.post(f'/api/presets/{preset_id}/apply', json={'date': '2024-01-01', 'meal_name': 'Meal 1'})
+        assert resp_apply.status_code == 200
+        assert resp_apply.json()['added'] == 1
+
+        day = client.get('/api/days/2024-01-01')
+        assert day.status_code == 200
+        assert len(day.json()['entries']) == 1

--- a/server/tests/test_weight.py
+++ b/server/tests/test_weight.py
@@ -43,3 +43,34 @@ def test_set_and_get_weight():
         resp2 = client.get("/api/weight/2024-01-01")
         assert resp2.status_code == 200
         assert resp2.json()["weight"] == 180
+
+
+def test_update_weight_overwrites_previous():
+    engine = get_test_engine()
+    db.engine = engine
+    app.app.dependency_overrides[db.get_session] = override_get_session(engine)
+
+    with TestClient(app.app) as client:
+        SQLModel.metadata.create_all(engine)
+
+        resp = client.put("/api/weight/2024-01-01", json={"weight": 180})
+        assert resp.status_code == 200
+
+        resp = client.put("/api/weight/2024-01-01", json={"weight": 182})
+        assert resp.status_code == 200
+
+        resp2 = client.get("/api/weight/2024-01-01")
+        assert resp2.status_code == 200
+        assert resp2.json()["weight"] == 182
+
+
+def test_get_weight_not_found():
+    engine = get_test_engine()
+    db.engine = engine
+    app.app.dependency_overrides[db.get_session] = override_get_session(engine)
+
+    with TestClient(app.app) as client:
+        SQLModel.metadata.create_all(engine)
+
+        resp = client.get("/api/weight/2024-02-01")
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- test meal creation, entry CRUD, presets, and weight API behaviour
- run test suite in GitHub Actions on every push and PR

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a5adda8ac8327bcbc06562dcc3962