### PR TITLE
fix: expose ASGI app at repository root

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,9 @@
+"""ASGI entrypoint for Uvicorn.
+
+This allows running ``uvicorn main:app`` from the repository
+root by re-exporting the FastAPI ``app`` defined in
+``server.app``.
+"""
+
+from server.app import app
+


### PR DESCRIPTION
## Summary
- add root-level `main.py` to allow running `uvicorn main:app`

## Testing
- `pytest server/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_689b719b50e08327a2332d89a15aa84c