### PR TITLE
fix meal entry sort order initialization

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -45,7 +45,7 @@ def ensure_entry_sort_order_column(session: Session):
         session.commit()
         # initialize existing entries sequentially per meal
         meals = session.exec(select(Meal.id).order_by(Meal.id)).all()
-        for (meal_id,) in meals:
+        for meal_id in meals:
             ents = session.exec(select(FoodEntry).where(FoodEntry.meal_id == meal_id).order_by(FoodEntry.id)).all()
             for idx, e in enumerate(ents, start=1):
                 e.sort_order = idx


### PR DESCRIPTION
## Summary
- fix iteration when initializing new `foodentry.sort_order` values to handle scalar results

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b7b942cfc83278f25ac057f885238