### PR TITLE
Add missing dependencies for server tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 fastapi
 sqlmodel
+platformdirs
+httpx
+python-dotenv


### PR DESCRIPTION
## Summary
- include platformdirs, httpx, and python-dotenv in requirements

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b7d3657ec83279a2d917ac396d0b5