### PR TITLE
fix: avoid blank screen on API init failure

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16,10 +16,18 @@ export default function App() {
 
   useEffect(() => {
     const run = async () => {
-      await init();
-      const key = await api.getUsdaKey();
-      setNeedsKey(!key);
-      setLoading(false);
+      try {
+        await init();
+        const key = await api.getUsdaKey();
+        setNeedsKey(!key);
+      } catch (err) {
+        // If the API call fails (e.g. backend is not running) the app would
+        // previously hang on the loading screen leaving users with a blank
+        // page.  Log the error and continue so the UI can render.
+        console.error("Failed to initialize application", err);
+      } finally {
+        setLoading(false);
+      }
     };
     run();
   }, [init]);


### PR DESCRIPTION
## Summary
- handle errors during app initialization and ensure loading spinner clears

## Testing
- `python -m pytest -q` *(fails: The starlette.testclient module requires the httpx package to be installed)*
- `npm --prefix web test` *(fails: Missing script "test")*
- `npm --prefix web run lint` *(fails: Package subpath './config' is not defined by "exports" in ESLint package)*

------
https://chatgpt.com/codex/tasks/task_e_689b7e0c6980832796fb934336b59994