### PR TITLE
Avoid hard dependency on platformdirs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 fastapi
 sqlmodel
-platformdirs
 httpx
 python-dotenv

--- a/server/db.py
+++ b/server/db.py
@@ -1,7 +1,13 @@
 from pathlib import Path
 import shutil
 
-from platformdirs import user_data_dir
+try:
+    from platformdirs import user_data_dir
+except ModuleNotFoundError:  # pragma: no cover
+    def user_data_dir(appname: str, appauthor: str) -> str:
+        """Fallback implementation if platformdirs is unavailable."""
+        return str(Path.home() / f".{appname}")
+
 from sqlmodel import Session, create_engine
 
 


### PR DESCRIPTION
## Summary
- provide a fallback user_data_dir when platformdirs is missing
- drop platformdirs from requirements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b7f1f69688327b46e9d1b5f5a611d