### PR TITLE
Add missing platformdirs dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 sqlmodel
 httpx
 python-dotenv
+platformdirs


### PR DESCRIPTION
## Summary
- Include `platformdirs` in dependencies to ensure server imports correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b811ad4b08327bb59158d2952d48a