### PR TITLE
handle backend init failures gracefully

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,7 @@ import { Layout } from "./components/Layout";
 import { LoadingSpinner } from "./components/LoadingSpinner";
 import { UsdaKeyDialog } from "./components/UsdaKeyDialog";
 import * as api from "./api";
+import toast from "react-hot-toast";
 
 export default function App() {
   const init = useStore((state) => state.init);
@@ -15,6 +16,8 @@ export default function App() {
   const [needsKey, setNeedsKey] = useState(false);
 
   useEffect(() => {
+    // Safeguard in case network requests hang indefinitely.
+    const timeout = setTimeout(() => setLoading(false), 5000);
     const run = async () => {
       try {
         await init();
@@ -25,7 +28,9 @@ export default function App() {
         // previously hang on the loading screen leaving users with a blank
         // page.  Log the error and continue so the UI can render.
         console.error("Failed to initialize application", err);
+        toast.error("Failed to reach backend. Some features may not work.");
       } finally {
+        clearTimeout(timeout);
         setLoading(false);
       }
     };


### PR DESCRIPTION
## Summary
- show an error toast when the backend cannot be reached during startup
- ensure app exits loading state after 5 seconds even if requests hang

## Testing
- `npm run build`
- `npm run lint` *(fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED])*

------
https://chatgpt.com/codex/tasks/task_e_689b83cfe8d8832791b24e35bcac1e92