### PR TITLE
fix: prevent QuickAdd update loop

### DIFF
--- a/web/src/components/QuickAdd.tsx
+++ b/web/src/components/QuickAdd.tsx
@@ -2,13 +2,17 @@ import { useStore } from "../store";
 import { Button } from "./ui/Button";
 
 export function QuickAdd() {
-  const foods = useStore(s => s.allMyFoods.slice(0,5));
   const addFood = useStore(s => s.addFood);
+  const foods = useStore(s => s.allMyFoods).slice(0, 5);
   if (!foods.length) return null;
   return (
     <div className="flex flex-wrap gap-2 mb-4">
       {foods.map(f => (
-        <Button key={f.fdcId} className="btn-secondary btn-sm" onClick={() => addFood(f.fdcId, f.defaultGrams ?? 100)}>
+        <Button
+          key={f.fdcId}
+          className="btn-secondary btn-sm"
+          onClick={() => addFood(f.fdcId, f.defaultGrams ?? 100)}
+        >
           {f.description}
         </Button>
       ))}


### PR DESCRIPTION
## Summary
- prevent QuickAdd from triggering a maximum update depth error by avoiding state selector creation of new arrays each render

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Package subpath './config' is not defined by "exports" in eslint)*

------
https://chatgpt.com/codex/tasks/task_e_689b9301b3508327af8b8e7e6f8ed7d9