### PR TITLE
Remove custom foods from quick-add section

### DIFF
--- a/web/src/components/QuickAdd.tsx
+++ b/web/src/components/QuickAdd.tsx
@@ -3,7 +3,11 @@ import { Button } from "./ui/Button";
 
 export function QuickAdd() {
   const addFood = useStore(s => s.addFood);
-  const foods = useStore(s => s.allMyFoods).slice(0, 5);
+  // Exclude custom foods from the quick‑add list to avoid duplicating
+  // items already shown in the "My Foods" section.
+  const foods = useStore(s => s.allMyFoods)
+    .filter(f => f.dataType !== "Custom")
+    .slice(0, 5);
   if (!foods.length) return null;
   return (
     <div className="flex flex-wrap gap-2 mb-4">


### PR DESCRIPTION
## Summary
- exclude custom foods from quick add list so they only appear under My Foods

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Package subpath './config' is not defined by "exports" in eslint)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b94e229fc83279938daf6ffa5b692