### PR TITLE
remove toast notifications for goals

### DIFF
--- a/web/src/components/Summary.tsx
+++ b/web/src/components/Summary.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from "react";
-import toast from 'react-hot-toast';
 import { useStore } from "../store";
 import RadialProgress from "./RadialProgress";
 import { Button } from "./ui/Button";
@@ -11,23 +10,11 @@ export function Summary() {
     const goals = useStore(state => state.goals);
     const saveWeight = useStore(state => state.saveWeight);
     const [input, setInput] = useState("");
-    const [achieved, setAchieved] = useState({kcal:false,fat:false,carb:false,protein:false});
 
     useEffect(() => {
         setInput(weight != null ? weight.toString() : "");
     }, [weight]);
 
-    useEffect(() => {
-        if (!totals) return;
-        (['kcal','fat','carb','protein'] as const).forEach(k => {
-            const goal = (goals as any)[k];
-            const val = (totals as any)[k];
-            if (!achieved[k] && goal > 0 && val >= goal) {
-                toast.success(`${k} goal reached!`);
-                setAchieved(prev => ({...prev, [k]: true}));
-            }
-        });
-    }, [totals, goals, achieved]);
 
     return (
         <div>


### PR DESCRIPTION
## Summary
- remove react-hot-toast calls when daily goals are reached

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED])*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b98166ff883279045a618f1eb7f52