### PR TITLE
Add favorites to quick add and search

### DIFF
--- a/web/src/components/QuickAdd.tsx
+++ b/web/src/components/QuickAdd.tsx
@@ -3,15 +3,11 @@ import { Button } from "./ui/Button";
 
 export function QuickAdd() {
   const addFood = useStore(s => s.addFood);
-  // Exclude custom foods from the quick‑add list to avoid duplicating
-  // items already shown in the "My Foods" section.
-  const foods = useStore(s => s.allMyFoods)
-    .filter(f => f.dataType !== "Custom")
-    .slice(0, 5);
-  if (!foods.length) return null;
+  const favorites = useStore(s => s.favorites);
+  if (!favorites.length) return null;
   return (
     <div className="flex flex-wrap gap-2 mb-4">
-      {foods.map(f => (
+      {favorites.map(f => (
         <Button
           key={f.fdcId}
           className="btn-secondary btn-sm"

--- a/web/src/components/control-panel/SearchTab.tsx
+++ b/web/src/components/control-panel/SearchTab.tsx
@@ -8,7 +8,7 @@ import { Button } from "../ui/Button";
 import { Input } from "../ui/Input";
 
 export function SearchTab() {
-  const { mealName, allMyFoods, setAllMyFoods, addFood } = useStore();
+  const { mealName, allMyFoods, setAllMyFoods, addFood, favorites, toggleFavorite } = useStore();
   const [isAddingFood, setIsAddingFood] = useState(false);
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<SimpleFood[]>([]);
@@ -128,12 +128,22 @@ export function SearchTab() {
                   onClick={() => setSelected(f.fdcId)}
                 >
                   <div className="font-medium truncate text-sm">{f.description}</div>
-                  <Button
-                    className="btn-ghost btn-sm text-brand-danger hover:bg-brand-danger/10 dark:hover:bg-brand-danger/30"
-                    title="Delete custom food"
-                    aria-label="Delete custom food"
-                    onClick={(e) => { e.stopPropagation(); handleDeleteCustomFood(f.fdcId); }}
-                  >🗑️</Button>
+                  <div className="flex items-center gap-1">
+                    <Button
+                      className="btn-ghost btn-sm"
+                      title={favorites.some(fav => fav.fdcId === f.fdcId) ? 'Remove favorite' : 'Add favorite'}
+                      aria-label={favorites.some(fav => fav.fdcId === f.fdcId) ? 'Remove favorite' : 'Add favorite'}
+                      onClick={(e) => { e.stopPropagation(); toggleFavorite(f); }}
+                    >{favorites.some(fav => fav.fdcId === f.fdcId) ? '⭐' : '☆'}</Button>
+                    {f.dataType === 'Custom' && (
+                      <Button
+                        className="btn-ghost btn-sm text-brand-danger hover:bg-brand-danger/10 dark:hover:bg-brand-danger/30"
+                        title="Delete custom food"
+                        aria-label="Delete custom food"
+                        onClick={(e) => { e.stopPropagation(); handleDeleteCustomFood(f.fdcId); }}
+                      >🗑️</Button>
+                    )}
+                  </div>
                 </li>
               ))}
             </ul>
@@ -147,11 +157,19 @@ export function SearchTab() {
             results.map(r => (
               <li
                 key={r.fdcId}
-                className={`p-2 cursor-pointer ${selected === r.fdcId ? 'bg-brand-primary/20 dark:bg-brand-primary/30' : 'hover:bg-surface-light dark:hover:bg-border-dark'}`}
+                className={`p-2 flex justify-between items-center cursor-pointer ${selected === r.fdcId ? 'bg-brand-primary/20 dark:bg-brand-primary/30' : 'hover:bg-surface-light dark:hover:bg-border-dark'}`}
                 onClick={() => setSelected(r.fdcId)}
               >
-                <div className="font-medium text-sm">{r.description}</div>
-                <div className="text-xs text-text-muted dark:text-text-muted-dark">{r.brandOwner || r.dataType}</div>
+                <div>
+                  <div className="font-medium text-sm">{r.description}</div>
+                  <div className="text-xs text-text-muted dark:text-text-muted-dark">{r.brandOwner || r.dataType}</div>
+                </div>
+                <Button
+                  className="btn-ghost btn-sm"
+                  title={favorites.some(f => f.fdcId === r.fdcId) ? 'Remove favorite' : 'Add favorite'}
+                  aria-label={favorites.some(f => f.fdcId === r.fdcId) ? 'Remove favorite' : 'Add favorite'}
+                  onClick={(e) => { e.stopPropagation(); toggleFavorite(r); }}
+                >{favorites.some(f => f.fdcId === r.fdcId) ? '⭐' : '☆'}</Button>
               </li>
             ))}
         </ul>


### PR DESCRIPTION
## Summary
- store and persist favorite foods
- show star toggle on search results and my foods
- quick add renders favorites list

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED])

------
https://chatgpt.com/codex/tasks/task_e_689cced7429c83278f563f59dcf2c3f7