### PR TITLE
feat: add onboarding flow for USDA API key

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,7 @@ import { NotFoundPage } from "./pages/NotFoundPage";
 import { Layout } from "./components/Layout";
 import { LoadingSpinner } from "./components/LoadingSpinner";
 import { UsdaKeyDialog } from "./components/UsdaKeyDialog";
+import { Onboarding } from "./components/Onboarding";
 import * as api from "./api";
 import toast from "react-hot-toast";
 
@@ -14,8 +15,17 @@ export default function App() {
   const init = useStore((state) => state.init);
   const [loading, setLoading] = useState(true);
   const [needsKey, setNeedsKey] = useState(false);
+  const [onboarded, setOnboarded] = useState(
+    () => !!localStorage.getItem("onboarding-complete")
+  );
+
+  const completeOnboarding = () => {
+    localStorage.setItem("onboarding-complete", "true");
+    setOnboarded(true);
+  };
 
   useEffect(() => {
+    if (!onboarded) return;
     // Safeguard in case network requests hang indefinitely.
     const timeout = setTimeout(() => setLoading(false), 5000);
     const run = async () => {
@@ -34,8 +44,12 @@ export default function App() {
         setLoading(false);
       }
     };
+    setLoading(true);
     run();
-  }, [init]);
+  }, [init, onboarded]);
+  if (!onboarded) {
+    return <Onboarding onComplete={completeOnboarding} />;
+  }
 
   if (loading) {
     return (

--- a/web/src/components/Onboarding.tsx
+++ b/web/src/components/Onboarding.tsx
@@ -1,0 +1,42 @@
+import { useState } from "react";
+import { Button } from "./ui/Button";
+import { UsdaKeyDialog } from "./UsdaKeyDialog";
+
+interface Props {
+  onComplete: () => void;
+}
+
+export function Onboarding({ onComplete }: Props) {
+  const [showDialog, setShowDialog] = useState(false);
+
+  const handleSaved = () => {
+    setShowDialog(false);
+    onComplete();
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-surface-light dark:bg-surface-dark p-4">
+      <div className="bg-white dark:bg-surface-dark max-w-md w-full p-6 rounded shadow">
+        <h1 className="text-xl font-semibold mb-4">Welcome</h1>
+        <p className="mb-4 text-sm">
+          This app uses the USDA FoodData Central API to search for foods. You'll need your own API key to use this feature.
+        </p>
+        <a
+          href="https://api.data.gov/signup/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary underline"
+        >
+          Request a USDA API Key
+        </a>
+        <div className="mt-6 text-right">
+          <Button onClick={() => setShowDialog(true)}>I have a key</Button>
+        </div>
+      </div>
+      {showDialog && <UsdaKeyDialog onSaved={handleSaved} />}
+    </div>
+  );
+}
+
+export default Onboarding;
+


### PR DESCRIPTION
## Summary
- add onboarding component with USDA API key explanation and request link
- show onboarding on first launch and initialize app after API key saved

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './config' is not defined by "exports" in eslint package.json)

------
https://chatgpt.com/codex/tasks/task_e_689cd0b01adc8327b85be1a98ff7a75b