### PR TITLE
Spawn Python backend and bundle server for desktop builds

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -34,7 +34,8 @@
         "tailwindcss": "^3.4.4",
         "typescript": "^5.0.2",
         "typescript-eslint": "^8.39.0",
-        "vite": "^4.4.5"
+        "vite": "^4.4.5",
+        "vite-plugin-static-copy": "^0.17.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2886,6 +2887,21 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3035,6 +3051,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -3347,6 +3370,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/keyv": {
@@ -4727,6 +4763,16 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
@@ -4860,6 +4906,25 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-plugin-static-copy": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-0.17.1.tgz",
+      "integrity": "sha512-9h3iaVs0bqnqZOM5YHJXGHqdC5VAVlTZ2ARYsuNpzhEJUHmFqXY7dAK4ZFpjEQ4WLFKcaN8yWbczr81n01U4sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.3",
+        "fast-glob": "^3.2.11",
+        "fs-extra": "^11.1.0",
+        "picocolors": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/which": {

--- a/web/package.json
+++ b/web/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build --mode production",
+    "build": "tsc -b && vite build --mode desktop",
+    "build:web": "tsc -b && vite build --mode production",
     "build:desktop": "tsc -b && vite build --mode desktop",
     "lint": "eslint .",
     "preview": "vite preview"
@@ -37,6 +38,7 @@
     "tailwindcss": "^3.4.4",
     "typescript": "^5.0.2",
     "typescript-eslint": "^8.39.0",
-    "vite": "^4.4.5"
+    "vite": "^4.4.5",
+    "vite-plugin-static-copy": "^0.17.1"
   }
 }

--- a/web/src-tauri/src/lib.rs
+++ b/web/src-tauri/src/lib.rs
@@ -1,16 +1,51 @@
+use std::process::{Child, Command};
+use std::sync::Mutex;
+use tauri::{async_runtime::spawn, Manager, RunEvent};
+
+struct BackendProcess(Mutex<Option<Child>>);
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   tauri::Builder::default()
     .setup(|app| {
       if cfg!(debug_assertions) {
-        app.handle().plugin(
-          tauri_plugin_log::Builder::default()
-            .level(log::LevelFilter::Info)
-            .build(),
-        )?;
+        app
+          .handle()
+          .plugin(
+            tauri_plugin_log::Builder::default()
+              .level(log::LevelFilter::Info)
+              .build(),
+          )?;
       }
+
+      app.manage(BackendProcess(Mutex::new(None)));
+      let handle = app.handle();
+
+      spawn(async move {
+        let script = handle
+          .path_resolver()
+          .resolve_resource("server/main.py")
+          .unwrap_or_else(|| "../server/main.py".into());
+
+        if let Ok(child) = Command::new("python").arg(script).spawn() {
+          handle
+            .state::<BackendProcess>()
+            .0
+            .lock()
+            .unwrap()
+            .replace(child);
+        }
+      });
+
       Ok(())
     })
-    .run(tauri::generate_context!())
-    .expect("error while running tauri application");
+    .build(tauri::generate_context!())
+    .expect("error while building tauri application")
+    .run(|app, event| {
+      if let RunEvent::Exit = event {
+        if let Some(child) = app.state::<BackendProcess>().0.lock().unwrap().as_mut() {
+          let _ = child.kill();
+        }
+      }
+    });
 }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,6 +1,14 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { viteStaticCopy } from 'vite-plugin-static-copy'
 
-export default defineConfig({
-  plugins: [react()],
-})
+export default defineConfig(({ mode }) => ({
+  plugins: [
+    react(),
+    mode === 'desktop'
+      ? viteStaticCopy({
+          targets: [{ src: '../server/**/*', dest: 'server' }],
+        })
+      : undefined,
+  ].filter(Boolean),
+}))


### PR DESCRIPTION
## Summary
- Spawn Python backend during Tauri setup and clean it up on exit
- Copy backend server files into desktop builds via Vite static copy plugin
- Adjust build scripts and dependencies to bundle backend scripts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint config package path not exported)*
- `cargo test` *(fails: The system library `gdk-3.0` required by crate `gdk-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cddeccd8c83278bf0b97182534ff8