### PR TITLE
Add global hotkeys and shortcuts modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,12 @@ VITE_API_BASE_URL=https://example.com
 ```
 
 Production builds use `npm run build` and desktop builds use `npm run build:desktop`.
+
+## Keyboard Shortcuts
+
+The application supports a few global shortcuts:
+
+- `Ctrl+M` — add a new meal.
+- `Ctrl+F` — focus the food search box.
+- `Ctrl+T` — toggle between light and dark themes.
+- `?` — show the in-app shortcuts help.

--- a/web/src/components/Hotkeys.tsx
+++ b/web/src/components/Hotkeys.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useState } from "react";
+import { useStore } from "../store";
+import { Button } from "./ui/Button";
+
+export function Hotkeys() {
+  const addMeal = useStore(s => s.addMeal);
+  const toggleTheme = useStore(s => s.toggleTheme);
+  const focusSearch = useStore(s => s.focusSearch);
+  const [showHelp, setShowHelp] = useState(false);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const key = e.key.toLowerCase();
+      if (e.shiftKey && e.key === "?") {
+        e.preventDefault();
+        setShowHelp(o => !o);
+        return;
+      }
+      if (e.key === "Escape") {
+        setShowHelp(false);
+      }
+      if (e.ctrlKey || e.metaKey) {
+        if (key === "m") {
+          e.preventDefault();
+          addMeal();
+        } else if (key === "f") {
+          e.preventDefault();
+          focusSearch();
+        } else if (key === "t") {
+          e.preventDefault();
+          toggleTheme();
+        }
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [addMeal, toggleTheme, focusSearch]);
+
+  if (!showHelp) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={() => setShowHelp(false)}>
+      <div
+        className="bg-surface-light dark:bg-surface-dark rounded-md p-6 shadow-lg text-text dark:text-text-light"
+        onClick={e => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+      >
+        <h2 className="text-lg font-semibold mb-4">Keyboard Shortcuts</h2>
+        <ul className="space-y-2 text-sm">
+          <li><kbd className="px-1 py-0.5 rounded bg-border-light dark:bg-border-dark font-mono text-xs">Ctrl</kbd>+
+              <kbd className="px-1 py-0.5 rounded bg-border-light dark:bg-border-dark font-mono text-xs">M</kbd> Add meal</li>
+          <li><kbd className="px-1 py-0.5 rounded bg-border-light dark:bg-border-dark font-mono text-xs">Ctrl</kbd>+
+              <kbd className="px-1 py-0.5 rounded bg-border-light dark:bg-border-dark font-mono text-xs">F</kbd> Focus search</li>
+          <li><kbd className="px-1 py-0.5 rounded bg-border-light dark:bg-border-dark font-mono text-xs">Ctrl</kbd>+
+              <kbd className="px-1 py-0.5 rounded bg-border-light dark:bg-border-dark font-mono text-xs">T</kbd> Toggle theme</li>
+          <li><kbd className="px-1 py-0.5 rounded bg-border-light dark:bg-border-dark font-mono text-xs">?</kbd> Toggle this help</li>
+        </ul>
+        <Button className="btn-primary mt-4" onClick={() => setShowHelp(false)}>Close</Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { NavLink } from "react-router-dom";
 import { Toaster } from 'react-hot-toast';
 import { ThemeToggle } from "./ThemeToggle";
+import { Hotkeys } from "./Hotkeys";
 import { Bars3Icon, XMarkIcon, HomeIcon, ChartBarIcon } from "@heroicons/react/24/outline";
 
 interface LayoutProps {
@@ -46,6 +47,7 @@ export function Layout({ children }: LayoutProps) {
   return (
     <div className="min-h-screen bg-surface-light dark:bg-surface-dark font-sans">
       <Toaster position="bottom-center" toastOptions={{ style: { background: '#363636', color: '#fff' }, success: { duration: 3000 } }} />
+      <Hotkeys />
 
       <header className="sticky top-0 z-10 bg-surface-light dark:bg-surface-dark">
         <div className="mx-auto flex items-center justify-between px-4 py-4 lg:px-6">

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -23,6 +23,7 @@ interface AppActions {
   copyMeal: (mealId: number) => void;
   pasteMeal: () => Promise<void>;
   toggleTheme: () => void;
+  focusSearch: () => void;
   init: () => Promise<void>;
   setDate: (newDate: string) => void;
   setMealName: (newName: string) => void;
@@ -121,6 +122,15 @@ export const useStore = create<AppState & AppActions>((set, get) => ({
     document.documentElement.classList.add(newTheme);
     localStorage.setItem('theme', newTheme);
     set({ theme: newTheme });
+  },
+
+  focusSearch: () => {
+    if (typeof document === 'undefined') return;
+    const el = document.getElementById('search-query') as HTMLInputElement | null;
+    if (el) {
+      el.focus();
+      el.select();
+    }
   },
 
   init: async () => {


### PR DESCRIPTION
## Summary
- implement Hotkeys component to capture key combos (Ctrl+M, Ctrl+F, Ctrl+T) and provide help modal
- expose `focusSearch` in store and mount Hotkeys in Layout
- document available keyboard shortcuts in README

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED])
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ce4b567788327ac4a6cbc4e87d04c