### PR TITLE
Avoid browser conflict for theme toggle hotkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,5 @@ The application supports a few global shortcuts:
 
 - `Ctrl+M` — add a new meal.
 - `Ctrl+F` — focus the food search box.
-- `Ctrl+T` — toggle between light and dark themes.
+- `Ctrl+Shift+L` — toggle between light and dark themes.
 - `?` — show the in-app shortcuts help.

--- a/web/src/components/Hotkeys.tsx
+++ b/web/src/components/Hotkeys.tsx
@@ -26,7 +26,7 @@ export function Hotkeys() {
         } else if (key === "f") {
           e.preventDefault();
           focusSearch();
-        } else if (key === "t") {
+        } else if (e.shiftKey && key === "l") {
           e.preventDefault();
           toggleTheme();
         }
@@ -52,7 +52,8 @@ export function Hotkeys() {
           <li><kbd className="px-1 py-0.5 rounded bg-border-light dark:bg-border-dark font-mono text-xs">Ctrl</kbd>+
               <kbd className="px-1 py-0.5 rounded bg-border-light dark:bg-border-dark font-mono text-xs">F</kbd> Focus search</li>
           <li><kbd className="px-1 py-0.5 rounded bg-border-light dark:bg-border-dark font-mono text-xs">Ctrl</kbd>+
-              <kbd className="px-1 py-0.5 rounded bg-border-light dark:bg-border-dark font-mono text-xs">T</kbd> Toggle theme</li>
+              <kbd className="px-1 py-0.5 rounded bg-border-light dark:bg-border-dark font-mono text-xs">Shift</kbd>+
+              <kbd className="px-1 py-0.5 rounded bg-border-light dark:bg-border-dark font-mono text-xs">L</kbd> Toggle theme</li>
           <li><kbd className="px-1 py-0.5 rounded bg-border-light dark:bg-border-dark font-mono text-xs">?</kbd> Toggle this help</li>
         </ul>
         <Button className="btn-primary mt-4" onClick={() => setShowHelp(false)}>Close</Button>


### PR DESCRIPTION
## Summary
- require Ctrl+Shift+L to toggle between light and dark themes
- document new theme toggle shortcut

## Testing
- `npm run lint` *(fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED] from ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_689ce6e1ca38832784c7bb164eaab4e7