### PR TITLE
fix: align meal subtotal macros

### DIFF
--- a/web/src/components/DailyLog.tsx
+++ b/web/src/components/DailyLog.tsx
@@ -249,22 +249,22 @@ function MealCard({ meal, isCurrent, onSelect, onUpdateEntry, onDeleteEntry, onD
           </Droppable>
           <tfoot className="block sm:table-footer-group">
             <tr className="font-semibold border-t-2 border-border-light dark:border-border-dark block sm:table-row">
-                <td className="p-3 flex justify-between sm:block sm:text-right" colSpan={2}>
+                <td className="p-3 flex justify-between sm:table-cell sm:text-right" colSpan={2}>
                   <span className="sm:hidden">Subtotal</span>
                 </td>
-                <td className="p-3 subtotal-kcal flex justify-between sm:block sm:text-right">
+                <td className="p-3 subtotal-kcal flex justify-between sm:table-cell sm:text-right">
                   <span className="sm:hidden">kcal</span>
                   <span>{meal.subtotal.kcal.toFixed(1)}</span>
                 </td>
-                <td className="p-3 subtotal-fat flex justify-between sm:block sm:text-right">
+                <td className="p-3 subtotal-fat flex justify-between sm:table-cell sm:text-right">
                   <span className="sm:hidden">F</span>
                   <span>{meal.subtotal.fat.toFixed(1)}</span>
                 </td>
-                <td className="p-3 subtotal-carb flex justify-between sm:block sm:text-right">
+                <td className="p-3 subtotal-carb flex justify-between sm:table-cell sm:text-right">
                   <span className="sm:hidden">C</span>
                   <span>{meal.subtotal.carb.toFixed(1)}</span>
                 </td>
-                <td className="p-3 subtotal-protein flex justify-between sm:block sm:text-right">
+                <td className="p-3 subtotal-protein flex justify-between sm:table-cell sm:text-right">
                   <span className="sm:hidden">P</span>
                   <span>{meal.subtotal.protein.toFixed(1)}</span>
                 </td>


### PR DESCRIPTION
## Summary
- align meal subtotal macros (kcal, F, C, P) by using table-cell layout on larger screens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint configuration error: Package subpath './config' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689d48f53ebc83279962d888e48ce45d