### PR TITLE
Remove duplicate top right search bar

### DIFF
--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -3,7 +3,6 @@ import { NavLink } from "react-router-dom";
 import { Toaster } from 'react-hot-toast';
 import { ThemeToggle } from "./ThemeToggle";
 import { Hotkeys } from "./Hotkeys";
-import { SearchBar } from "./SearchBar";
 import { Bars3Icon, XMarkIcon, HomeIcon, ChartBarIcon } from "@heroicons/react/24/outline";
 
 interface LayoutProps {
@@ -67,9 +66,6 @@ export function Layout({ children }: LayoutProps) {
                 </NavLink>
               ))}
             </nav>
-            <div className="hidden lg:block w-64">
-              <SearchBar />
-            </div>
             <ThemeToggle />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- remove SearchBar import and component from Layout to avoid duplicate search UI

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Package subpath './config' not defined in ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_689d4da9aedc8327a25d85008655ae3a