### PR TITLE
feat: reuse last saved goals

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,9 @@ The application supports a few global shortcuts:
 - `Ctrl+F` — focus the food search box.
 - `Ctrl+Shift+L` — toggle between light and dark themes.
 - `?` — show the in-app shortcuts help.
+
+## Daily Goals
+
+When you save macro goals they are stored as the default for future days. New dates
+will automatically use the most recently saved goals unless you override them for
+that specific day.

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -57,6 +57,16 @@ const getInitialTheme = (): Theme => {
 // --- Daily Goals helpers -------------------------------------------------
 const EMPTY_GOALS: Goals = { kcal: 0, protein: 0, fat: 0, carb: 0 };
 
+// Return default goals saved in localStorage, or empty goals if none set
+const loadDefaultGoals = (): Goals => {
+  if (typeof window === 'undefined') return { ...EMPTY_GOALS };
+  try {
+    return JSON.parse(localStorage.getItem('defaultGoals') || JSON.stringify(EMPTY_GOALS));
+  } catch {
+    return { ...EMPTY_GOALS };
+  }
+};
+
 // Return full mapping of date -> goals from localStorage
 const loadGoalsMap = (): Record<string, Goals> => {
   if (typeof window === 'undefined') return {};
@@ -70,7 +80,7 @@ const loadGoalsMap = (): Record<string, Goals> => {
 // Load goals for specific date
 const getGoalsForDate = (d: string): Goals => {
   const all = loadGoalsMap();
-  return all[d] || { ...EMPTY_GOALS };
+  return all[d] || loadDefaultGoals();
 };
 
 // --- Favorites helpers ---------------------------------------------------
@@ -259,6 +269,7 @@ export const useStore = create<AppState & AppActions>((set, get) => ({
       const all = loadGoalsMap();
       all[get().date] = g;
       localStorage.setItem('goalsByDate', JSON.stringify(all));
+      localStorage.setItem('defaultGoals', JSON.stringify(g));
     }
     set({ goals: g });
   },


### PR DESCRIPTION
## Summary
- fallback to default macro goals when opening a new day
- store latest goals as default for future days
- document new daily goal behaviour

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED])*
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d5105c0d88327b9abcfd7cf81ce97