### PR TITLE
Ensure os and sys imports in test modules

### DIFF
--- a/server/tests/test_delete_meal.py
+++ b/server/tests/test_delete_meal.py
@@ -1,5 +1,6 @@
 import os
 import sys
+
 from pathlib import Path
 
 os.environ['USDA_KEY'] = 'test'

--- a/server/tests/test_entry_crud.py
+++ b/server/tests/test_entry_crud.py
@@ -1,5 +1,6 @@
 import os
 import sys
+
 from pathlib import Path
 
 os.environ['USDA_KEY'] = 'test'

--- a/server/tests/test_history.py
+++ b/server/tests/test_history.py
@@ -1,5 +1,6 @@
 import os
 import sys
+
 from pathlib import Path
 
 os.environ['USDA_KEY'] = 'test'


### PR DESCRIPTION
## Summary
- Group standard library imports at top of meal deletion, entry CRUD, and history tests to include `os` and `sys`

## Testing
- `pytest server/tests/test_delete_meal.py server/tests/test_entry_crud.py server/tests/test_history.py`

------
https://chatgpt.com/codex/tasks/task_e_689e10a219888327a34f9076d2a2a694