### PR TITLE
Refactor imports and test setup for server package

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -6,14 +6,9 @@ from fastapi.middleware.cors import CORSMiddleware
 from sqlmodel import SQLModel, Session, select
 from sqlalchemy import text
 
-try:
-    from .db import get_session, get_engine
-    from .models import Meal, Food, FoodEntry
-    from .routers import foods, meals, presets, history, weight, config
-except ImportError:  # pragma: no cover
-    from db import get_session, get_engine
-    from models import Meal, Food, FoodEntry
-    from routers import foods, meals, presets, history, weight, config
+from server.db import get_session, get_engine
+from server.models import Meal, Food, FoodEntry
+from server.routers import foods, meals, presets, history, weight, config
 
 def ensure_meal_sort_order_column(session: Session):
     tbl = session.exec(text("SELECT name FROM sqlite_master WHERE type='table' AND name='meal'")).first()

--- a/server/main.py
+++ b/server/main.py
@@ -1,24 +1,4 @@
-"""Expose the FastAPI ``app`` instance for ASGI servers.
+"""Expose the FastAPI application instance for ASGI servers."""
 
-This module allows the server package to be executed in a couple of ways:
-
-* ``uvicorn server.main:app`` when the ``server`` package is on the import
-  path.
-* ``python server/main.py`` when running from within the ``server`` directory.
-
-Previously, ``main.py`` unconditionally imported ``app`` using an absolute
-import.  This worked only when executing the file directly from the ``server``
-directory but failed when the module was imported as part of the ``server``
-package (e.g. ``uvicorn server.main:app``).  That scenario raised a
-``ModuleNotFoundError`` because the top-level ``app`` module could not be
-found.
-
-To support both use cases we try a package-relative import first and fall back
-to the absolute import when ``main.py`` is executed as a script.
-"""
-
-try:  # pragma: no cover - exercised in integration but trivial to test
-    from .app import app
-except ImportError:  # pragma: no cover
-    from app import app  # type: ignore
+from server.app import app
 

--- a/server/routers/__init__.py
+++ b/server/routers/__init__.py
@@ -1,2 +1,3 @@
-from . import foods, meals, presets, history, weight, config
+from server.routers import foods, meals, presets, history, weight, config
+
 __all__ = ["foods", "meals", "presets", "history", "weight", "config"]

--- a/server/routers/config.py
+++ b/server/routers/config.py
@@ -1,10 +1,7 @@
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
-try:
-    from .. import utils
-except ImportError:  # pragma: no cover
-    import utils
+from server import utils
 
 router = APIRouter()
 

--- a/server/routers/foods.py
+++ b/server/routers/foods.py
@@ -6,14 +6,9 @@ from sqlmodel import Session, select, delete
 from sqlalchemy import func
 from pydantic import BaseModel, field_validator
 
-try:
-    from ..db import get_session
-    from ..models import Food, FoodEntry, Favorite
-    from .. import utils
-except ImportError:  # pragma: no cover
-    from db import get_session
-    from models import Food, FoodEntry, Favorite
-    import utils
+from server.db import get_session
+from server.models import Food, FoodEntry, Favorite
+from server import utils
 
 USDA_BASE = utils.USDA_BASE
 fetch_food_detail = utils.fetch_food_detail

--- a/server/routers/history.py
+++ b/server/routers/history.py
@@ -4,12 +4,8 @@ from typing import Dict
 from fastapi import APIRouter, Depends
 from sqlmodel import Session, select
 
-try:
-    from ..db import get_session
-    from ..models import Meal, FoodEntry, Food, BodyWeight
-except ImportError:  # pragma: no cover
-    from db import get_session
-    from models import Meal, FoodEntry, Food, BodyWeight
+from server.db import get_session
+from server.models import Meal, FoodEntry, Food, BodyWeight
 
 router = APIRouter()
 

--- a/server/routers/meals.py
+++ b/server/routers/meals.py
@@ -7,14 +7,9 @@ from sqlmodel import Session, select
 from sqlalchemy import func, delete
 from pydantic import BaseModel
 
-try:
-    from ..db import get_session
-    from ..models import Meal, FoodEntry, Food
-    from ..utils import get_or_create_meal, ensure_food_cached
-except ImportError:  # pragma: no cover
-    from db import get_session
-    from models import Meal, FoodEntry, Food
-    from utils import get_or_create_meal, ensure_food_cached
+from server.db import get_session
+from server.models import Meal, FoodEntry, Food
+from server.utils import get_or_create_meal, ensure_food_cached
 
 router = APIRouter()
 

--- a/server/routers/presets.py
+++ b/server/routers/presets.py
@@ -5,14 +5,9 @@ from sqlmodel import Session, select, delete
 from sqlalchemy import func
 from pydantic import BaseModel
 
-try:
-    from ..db import get_session
-    from ..models import Preset, PresetItem, Food, Meal, FoodEntry
-    from ..utils import get_or_create_meal, ensure_food_cached
-except ImportError:  # pragma: no cover
-    from db import get_session
-    from models import Preset, PresetItem, Food, Meal, FoodEntry
-    from utils import get_or_create_meal, ensure_food_cached
+from server.db import get_session
+from server.models import Preset, PresetItem, Food, Meal, FoodEntry
+from server.utils import get_or_create_meal, ensure_food_cached
 
 router = APIRouter()
 

--- a/server/routers/weight.py
+++ b/server/routers/weight.py
@@ -4,12 +4,8 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlmodel import Session
 
-try:
-    from ..db import get_session
-    from ..models import BodyWeight
-except ImportError:  # pragma: no cover
-    from db import get_session
-    from models import BodyWeight
+from server.db import get_session
+from server.models import BodyWeight
 
 router = APIRouter()
 

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -1,0 +1,8 @@
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+os.environ.setdefault("PYTHONPATH", str(ROOT))

--- a/server/tests/test_delete_meal.py
+++ b/server/tests/test_delete_meal.py
@@ -1,12 +1,6 @@
 import os
-import sys
-
-from pathlib import Path
 
 os.environ['USDA_KEY'] = 'test'
-
-# Allow importing the server modules
-sys.path.append(str(Path(__file__).resolve().parents[2]))
 
 from fastapi.testclient import TestClient
 from sqlmodel import SQLModel, Session, create_engine, select

--- a/server/tests/test_entry_crud.py
+++ b/server/tests/test_entry_crud.py
@@ -1,11 +1,6 @@
 import os
-import sys
-
-from pathlib import Path
 
 os.environ['USDA_KEY'] = 'test'
-
-sys.path.append(str(Path(__file__).resolve().parents[2]))
 
 from fastapi.testclient import TestClient
 from sqlmodel import SQLModel, Session, create_engine

--- a/server/tests/test_history.py
+++ b/server/tests/test_history.py
@@ -1,12 +1,6 @@
 import os
-import sys
-
-from pathlib import Path
 
 os.environ['USDA_KEY'] = 'test'
-
-# Allow importing the server modules
-sys.path.append(str(Path(__file__).resolve().parents[2]))
 
 from fastapi.testclient import TestClient
 from sqlmodel import SQLModel, Session, create_engine

--- a/server/tests/test_meal_creation.py
+++ b/server/tests/test_meal_creation.py
@@ -1,11 +1,6 @@
 import os
-import sys
-from pathlib import Path
 
 os.environ['USDA_KEY'] = 'test'
-
-# Allow importing the server modules
-sys.path.append(str(Path(__file__).resolve().parents[2]))
 
 from fastapi.testclient import TestClient
 from sqlmodel import SQLModel, Session, create_engine

--- a/server/tests/test_presets.py
+++ b/server/tests/test_presets.py
@@ -1,10 +1,6 @@
 import os
-import sys
-from pathlib import Path
 
 os.environ['USDA_KEY'] = 'test'
-
-sys.path.append(str(Path(__file__).resolve().parents[2]))
 
 from fastapi.testclient import TestClient
 from sqlmodel import SQLModel, Session, create_engine

--- a/server/tests/test_usda_key_endpoint.py
+++ b/server/tests/test_usda_key_endpoint.py
@@ -1,14 +1,10 @@
-import os
-import sys
 import json
-from pathlib import Path
 
 # ensure config path temporary
 
 def test_usda_key_update(tmp_path, monkeypatch):
     monkeypatch.setenv('USDA_CONFIG_PATH', str(tmp_path / 'cfg.json'))
     monkeypatch.setenv('USDA_KEY', 'envkey')
-    sys.path.append(str(Path(__file__).resolve().parents[2]))
     from importlib import reload
     import server.utils as utils
     reload(utils)

--- a/server/tests/test_weight.py
+++ b/server/tests/test_weight.py
@@ -1,10 +1,6 @@
 import os
-import sys
-from pathlib import Path
 
 os.environ['USDA_KEY'] = 'test'
-
-sys.path.append(str(Path(__file__).resolve().parents[2]))
 
 from fastapi.testclient import TestClient
 from sqlmodel import SQLModel, Session, create_engine

--- a/server/utils.py
+++ b/server/utils.py
@@ -9,10 +9,7 @@ from fastapi import HTTPException
 from sqlmodel import Session, select
 from sqlalchemy import func
 
-try:
-    from .models import Food, Meal
-except ImportError:  # pragma: no cover
-    from models import Food, Meal
+from server.models import Food, Meal
 
 USDA_BASE = "https://api.nal.usda.gov/fdc/v1"
 from dotenv import load_dotenv, find_dotenv


### PR DESCRIPTION
## Summary
- Replace relative/fallback imports with absolute `server.*` imports
- Simplify `server.main` and remove redundant try/except blocks
- Centralize test PYTHONPATH handling via `server/tests/conftest.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e1209ce4c83278b0b58c6d9d5930b