### PR TITLE
feat: type offline queue operations

### DIFF
--- a/web/src/utils/storage.ts
+++ b/web/src/utils/storage.ts
@@ -1,0 +1,14 @@
+export function loadJSON<T>(key: string, fallback: T): T {
+  if (typeof window === "undefined") return fallback;
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as T) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export function saveJSON<T>(key: string, value: T): void {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(key, JSON.stringify(value));
+}


### PR DESCRIPTION
## Summary
- add discriminated OfflineOp union for offline queue
- ensure queue helper enforces OfflineOp and dispatch sync on `kind`
- share localStorage JSON helpers across API and store

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Package subpath './config' is not defined by exports)*
- `npm run build` *(fails: TypeScript errors in src/store.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689e1a5f61508327977e3cb2099abd15