### PR TITLE
Add Alembic migrations for new columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ VITE_API_BASE_URL=https://example.com
 
 Production builds use `npm run build` and desktop builds use `npm run build:desktop`.
 
+## Database Migrations
+
+The backend uses Alembic for database migrations. When the API starts it will
+automatically run any pending migrations. To apply migrations manually, run:
+
+```
+alembic upgrade head
+```
+
+This ensures the database has the latest columns, such as `sort_order` on meals
+and food entries and the `archived` flag on foods.
+
 ## Keyboard Shortcuts
 
 The application supports a few global shortcuts:

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = server/alembic
+sqlalchemy.url = sqlite:///foodlog.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ sqlmodel
 httpx
 python-dotenv
 platformdirs
+alembic

--- a/server/alembic/env.py
+++ b/server/alembic/env.py
@@ -1,0 +1,57 @@
+import sys
+from logging.config import fileConfig
+from pathlib import Path
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+from sqlmodel import SQLModel
+
+# Ensure application root is on path
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from server.db import DATABASE_URL  # noqa
+import server.models  # noqa: F401 ensures models are imported
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+config.set_main_option("sqlalchemy.url", DATABASE_URL)
+
+target_metadata = SQLModel.metadata
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=DATABASE_URL,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/server/alembic/versions/0001_add_sort_order_and_archived.py
+++ b/server/alembic/versions/0001_add_sort_order_and_archived.py
@@ -1,0 +1,54 @@
+"""Add sort_order and archived columns"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0001_add_sort_order_and_archived"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def _has_column(conn, table: str, column: str) -> bool:
+    rows = conn.execute(sa.text(f"PRAGMA table_info({table})")).fetchall()
+    return any(row[1] == column for row in rows)
+
+
+def _has_table(conn, table: str) -> bool:
+    row = conn.execute(sa.text("SELECT name FROM sqlite_master WHERE type='table' AND name=:name"), {"name": table}).first()
+    return row is not None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    if _has_table(conn, "meal") and not _has_column(conn, "meal", "sort_order"):
+        conn.execute(sa.text("ALTER TABLE meal ADD COLUMN sort_order INTEGER"))
+        meals = conn.execute(sa.text("SELECT id, name FROM meal WHERE sort_order IS NULL")).fetchall()
+        for m_id, name in meals:
+            try:
+                num = int(name.replace('Meal', '').strip())
+            except Exception:
+                num = 99
+            conn.execute(sa.text("UPDATE meal SET sort_order = :num WHERE id = :id"), {"num": num, "id": m_id})
+
+    if _has_table(conn, "foodentry") and not _has_column(conn, "foodentry", "sort_order"):
+        conn.execute(sa.text("ALTER TABLE foodentry ADD COLUMN sort_order INTEGER"))
+        rows = conn.execute(sa.text("SELECT id, meal_id FROM foodentry ORDER BY meal_id, id")).fetchall()
+        current_meal = None
+        count = 0
+        for entry_id, meal_id in rows:
+            if meal_id != current_meal:
+                current_meal = meal_id
+                count = 1
+            else:
+                count += 1
+            conn.execute(sa.text("UPDATE foodentry SET sort_order = :num WHERE id = :id"), {"num": count, "id": entry_id})
+
+    if _has_table(conn, "food") and not _has_column(conn, "food", "archived"):
+        conn.execute(sa.text("ALTER TABLE food ADD COLUMN archived INTEGER NOT NULL DEFAULT 0"))
+
+
+def downgrade() -> None:
+    pass

--- a/server/app.py
+++ b/server/app.py
@@ -3,69 +3,18 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from sqlmodel import SQLModel, Session, select
-from sqlalchemy import text
+from sqlmodel import SQLModel
 
-from server.db import get_session, get_engine
-from server.models import Meal, Food, FoodEntry
+from server.db import get_engine
 from server.routers import foods, meals, presets, history, weight, config
-
-def ensure_meal_sort_order_column(session: Session):
-    tbl = session.exec(text("SELECT name FROM sqlite_master WHERE type='table' AND name='meal'")).first()
-    if not tbl:
-        return
-    cols = session.exec(text("PRAGMA table_info(meal)")).all()
-    names = {row[1] for row in cols}
-    if "sort_order" not in names:
-        session.exec(text("ALTER TABLE meal ADD COLUMN sort_order INTEGER"))
-        session.commit()
-        meals = session.exec(select(Meal).where(Meal.sort_order.is_(None))).all()
-        for m in meals:
-            try:
-                num = int(m.name.replace("Meal", "").strip())
-                m.sort_order = num
-            except:
-                m.sort_order = 99
-            session.add(m)
-        session.commit()
-
-def ensure_entry_sort_order_column(session: Session):
-    tbl = session.exec(text("SELECT name FROM sqlite_master WHERE type='table' AND name='foodentry'")).first()
-    if not tbl:
-        return
-    cols = session.exec(text("PRAGMA table_info(foodentry)")).all()
-    names = {row[1] for row in cols}
-    if "sort_order" not in names:
-        session.exec(text("ALTER TABLE foodentry ADD COLUMN sort_order INTEGER"))
-        session.commit()
-        # initialize existing entries sequentially per meal
-        meals = session.exec(select(Meal.id).order_by(Meal.id)).all()
-        for meal_id in meals:
-            ents = session.exec(select(FoodEntry).where(FoodEntry.meal_id == meal_id).order_by(FoodEntry.id)).all()
-            for idx, e in enumerate(ents, start=1):
-                e.sort_order = idx
-                session.add(e)
-        session.commit()
-
-def ensure_food_archived_column(session: Session):
-    tbl = session.exec(text("SELECT name FROM sqlite_master WHERE type='table' AND name='food'")).first()
-    if not tbl:
-        return
-    cols = session.exec(text("PRAGMA table_info(food)")).all()
-    names = {row[1] for row in cols}
-    if "archived" not in names:
-        session.exec(text("ALTER TABLE food ADD COLUMN archived INTEGER NOT NULL DEFAULT 0"))
-        session.commit()
+from server.run_migrations import run_migrations
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Initialize database tables and handle graceful shutdown."""
     engine = get_engine()
     SQLModel.metadata.create_all(engine)
-    with Session(engine) as s:
-        ensure_food_archived_column(s)
-        ensure_meal_sort_order_column(s)
-        ensure_entry_sort_order_column(s)
+    run_migrations()
     try:
         yield
     except asyncio.CancelledError:

--- a/server/run_migrations.py
+++ b/server/run_migrations.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+
+from .db import DATABASE_URL
+
+
+def run_migrations() -> None:
+    root_dir = Path(__file__).resolve().parent.parent
+    cfg = Config(str(root_dir / "alembic.ini"))
+    cfg.set_main_option("sqlalchemy.url", DATABASE_URL)
+    command.upgrade(cfg, "head")


### PR DESCRIPTION
## Summary
- integrate Alembic migration framework
- migrate existing databases to add `sort_order` and `archived` columns
- run migrations during API startup and document migration workflow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e20c378888327a3cef5b433d88276