### PR TITLE
feat: add Alembic migrations for sort order and archived columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,19 @@ The application supports a few global shortcuts:
 - `Ctrl+Shift+L` — toggle between light and dark themes.
 - `?` — show the in-app shortcuts help.
 
+## Database Migrations
+
+This project uses Alembic to manage database schema changes. Migrations run
+automatically when the API starts, ensuring the database is up to date. You can
+also apply them manually by executing:
+
+```
+python -m server.run_migrations
+```
+
+The initial migration adds the `sort_order` column to `meal` and `foodentry`
+tables and an `archived` column to `food`.
+
 ## Daily Goals
 
 When you save macro goals they are stored as the default for future days. New dates

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = sqlite:///./foodlog.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers = console
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers = console
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from logging.config import fileConfig
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+from sqlmodel import SQLModel
+
+from server import models  # noqa: F401
+from server.db import DATABASE_URL
+
+config = context.config
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+config.set_main_option("sqlalchemy.url", DATABASE_URL)
+
+target_metadata = SQLModel.metadata
+
+
+def run_migrations_offline() -> None:
+    context.configure(url=DATABASE_URL, target_metadata=target_metadata, literal_binds=True)
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = config.attributes.get("connection")
+    if connectable is None:
+        connectable = engine_from_config(
+            config.get_section(config.config_ini_section),
+            prefix="sqlalchemy.",
+            poolclass=pool.NullPool,
+        )
+        with connectable.connect() as connection:
+            context.configure(connection=connection, target_metadata=target_metadata)
+            with context.begin_transaction():
+                context.run_migrations()
+    else:
+        context.configure(connection=connectable, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/versions/16a51a1de3c0_add_sort_order_and_archived_columns.py
+++ b/alembic/versions/16a51a1de3c0_add_sort_order_and_archived_columns.py
@@ -1,0 +1,66 @@
+"""Add sort_order and archived columns
+
+Revision ID: 16a51a1de3c0
+Revises: 
+Create Date: 2024-09-16 00:00:00.000000
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+from sqlmodel import Session, select
+
+# revision identifiers, used by Alembic.
+revision = "16a51a1de3c0"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = inspect(bind)
+
+    if "sort_order" not in [c["name"] for c in insp.get_columns("meal")]:
+        op.add_column("meal", sa.Column("sort_order", sa.Integer()))
+        from server.models import Meal  # imported lazily
+        session = Session(bind=bind)
+        meals = session.exec(select(Meal).where(Meal.sort_order.is_(None))).all()
+        for m in meals:
+            try:
+                num = int(m.name.replace("Meal", "").strip())
+                m.sort_order = num
+            except Exception:
+                m.sort_order = 99
+            session.add(m)
+        session.commit()
+
+    if "sort_order" not in [c["name"] for c in insp.get_columns("foodentry")]:
+        op.add_column("foodentry", sa.Column("sort_order", sa.Integer()))
+        from server.models import Meal, FoodEntry  # imported lazily
+        session = Session(bind=bind)
+        meals = session.exec(select(Meal.id).order_by(Meal.id)).all()
+        for meal_id in meals:
+            ents = session.exec(
+                select(FoodEntry).where(FoodEntry.meal_id == meal_id).order_by(FoodEntry.id)
+            ).all()
+            for idx, e in enumerate(ents, start=1):
+                e.sort_order = idx
+                session.add(e)
+        session.commit()
+
+    if "archived" not in [c["name"] for c in insp.get_columns("food")]:
+        op.add_column("food", sa.Column("archived", sa.Boolean(), nullable=False, server_default="0"))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = inspect(bind)
+
+    if "archived" in [c["name"] for c in insp.get_columns("food")]:
+        op.drop_column("food", "archived")
+    if "sort_order" in [c["name"] for c in insp.get_columns("foodentry")]:
+        op.drop_column("foodentry", "sort_order")
+    if "sort_order" in [c["name"] for c in insp.get_columns("meal")]:
+        op.drop_column("meal", "sort_order")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ sqlmodel
 httpx
 python-dotenv
 platformdirs
+alembic

--- a/server/run_migrations.py
+++ b/server/run_migrations.py
@@ -8,13 +8,17 @@ suite functional without requiring Alembic as a hard dependency.
 from __future__ import annotations
 
 
-def run_migrations(config_path: str = "alembic.ini") -> None:
+def run_migrations(config_path: str = "alembic.ini", engine=None) -> None:
     """Run Alembic migrations if the package is installed.
 
     Parameters
     ----------
     config_path:
         Path to the Alembic configuration file. Defaults to ``alembic.ini``.
+    engine:
+        Optional SQLAlchemy engine. If provided, migrations run using this
+        engine's connection. Otherwise Alembic uses the configuration file's
+        ``sqlalchemy.url`` setting.
     """
     try:
         from alembic import command
@@ -24,4 +28,9 @@ def run_migrations(config_path: str = "alembic.ini") -> None:
         return
 
     cfg = Config(config_path)
-    command.upgrade(cfg, "head")
+    if engine is not None:
+        with engine.begin() as connection:
+            cfg.attributes["connection"] = connection
+            command.upgrade(cfg, "head")
+    else:
+        command.upgrade(cfg, "head")


### PR DESCRIPTION
## Summary
- integrate Alembic and migration runner
- replace manual column checks with migration on startup
- document how to run migrations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e26938f8083278c4093ee38ba58fc