### PR TITLE
feat: highlight exceeded daily goals in summary

### DIFF
--- a/web/src/components/RadialProgress.tsx
+++ b/web/src/components/RadialProgress.tsx
@@ -1,3 +1,5 @@
+import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
+
 interface RadialProgressProps {
     value: number;
     goal: number;
@@ -11,6 +13,7 @@ export function RadialProgress({ value, goal, color, decimals = 0, unit = "" }: 
     const radius = 28;
     const circumference = 2 * Math.PI * radius;
     const offset = circumference - (pct / 100) * circumference;
+    const exceeded = goal > 0 && value > goal;
 
     return (
         <div className="flex flex-col items-center">
@@ -40,6 +43,12 @@ export function RadialProgress({ value, goal, color, decimals = 0, unit = "" }: 
                         transform="rotate(-90 32 32)"
                     />
                 </svg>
+                {exceeded && (
+                    <div className="absolute -top-1 -right-1">
+                        <ExclamationTriangleIcon className="h-5 w-5 text-brand-danger" aria-hidden="true" />
+                        <span className="sr-only">Goal exceeded</span>
+                    </div>
+                )}
                 <div className="absolute inset-0 flex items-center justify-center text-sm font-bold text-text dark:text-text-light">
                     {value.toFixed(decimals)}{unit}
                 </div>


### PR DESCRIPTION
## Summary
- show an exclamation icon on radial progress when totals exceed daily goals

## Testing
- `npm run lint` (fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './config' is not defined by "exports")
- `npm run build` (fails: src/store.ts: MealType undefined errors)


------
https://chatgpt.com/codex/tasks/task_e_689e2e6917d48327903b300473520d57