### PR TITLE
Allow SQLite engine use across threads

### DIFF
--- a/server/db.py
+++ b/server/db.py
@@ -20,7 +20,11 @@ if old_db_path.exists() and not new_db_path.exists():
     shutil.move(str(old_db_path), str(new_db_path))
 
 DATABASE_URL = f"sqlite:///{new_db_path}"
-engine = create_engine(DATABASE_URL, echo=False)
+engine = create_engine(
+    DATABASE_URL,
+    echo=False,
+    connect_args={"check_same_thread": False},
+)
 
 def get_engine():
     return engine


### PR DESCRIPTION
## Summary
- configure SQLite engine with `check_same_thread=False` to support concurrent access

## Testing
- `pytest`
- Concurrent requests to running API server

------
https://chatgpt.com/codex/tasks/task_e_689e3167d7c88327bd62fea2b8b4c8cc