### PR TITLE
feat: show toast when day fetch fails

### DIFF
--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -208,7 +208,17 @@ export const useStore = create<AppState & AppActions>((set, get) => ({
       set({ day: d, weight: w?.weight ?? null });
       const mealExists = d.meals.some((m: MealType) => m.name === get().mealName);
       if (!mealExists) set({ mealName: d.meals[0]?.name || "Meal 1" });
-    } catch (error) { console.error("Failed to fetch day:", error);
+    } catch (error) {
+      toast.error('Failed to fetch day. Please check your connection and try again.');
+      const state = get();
+      if (!state.day) {
+        const placeholder: DayFull = {
+          date: state.date,
+          meals: [],
+          totals: { kcal: 0, protein: 0, fat: 0, carb: 0 },
+        };
+        set({ day: placeholder });
+      }
     }
   },
 


### PR DESCRIPTION
## Summary
- replace console error with toast on day fetch failure
- fallback to placeholder day if no prior data exists

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED])*


------
https://chatgpt.com/codex/tasks/task_e_689e34c1c9b883278b70f970af168e81