### PR TITLE
Add Python executable check for backend

### DIFF
--- a/web/src-tauri/Cargo.toml
+++ b/web/src-tauri/Cargo.toml
@@ -23,3 +23,5 @@ serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
 tauri = { version = "2.7.0" }
 tauri-plugin-log = "2"
+tauri-plugin-dialog = "2"
+which = "8"

--- a/web/src-tauri/src/lib.rs
+++ b/web/src-tauri/src/lib.rs
@@ -1,51 +1,72 @@
 use std::process::{Child, Command};
 use std::sync::Mutex;
 use tauri::{async_runtime::spawn, Manager, RunEvent};
+use tauri_plugin_dialog::{DialogExt, MessageDialogKind};
 
 struct BackendProcess(Mutex<Option<Child>>);
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-  tauri::Builder::default()
-    .setup(|app| {
-      if cfg!(debug_assertions) {
-        app
-          .handle()
-          .plugin(
-            tauri_plugin_log::Builder::default()
-              .level(log::LevelFilter::Info)
-              .build(),
-          )?;
-      }
+    tauri::Builder::default()
+        .plugin(tauri_plugin_dialog::init())
+        .setup(|app| {
+            if cfg!(debug_assertions) {
+                app.handle().plugin(
+                    tauri_plugin_log::Builder::default()
+                        .level(log::LevelFilter::Info)
+                        .build(),
+                )?;
+            }
 
-      app.manage(BackendProcess(Mutex::new(None)));
-      let handle = app.handle();
+            app.manage(BackendProcess(Mutex::new(None)));
+            let handle = app.handle().clone();
 
-      spawn(async move {
-        let script = handle
-          .path_resolver()
-          .resolve_resource("server/main.py")
-          .unwrap_or_else(|| "../server/main.py".into());
+            spawn(async move {
+                let script = handle
+                    .path()
+                    .resolve("server/main.py", tauri::path::BaseDirectory::Resource)
+                    .unwrap_or_else(|_| "../server/main.py".into());
 
-        if let Ok(child) = Command::new("python").arg(script).spawn() {
-          handle
-            .state::<BackendProcess>()
-            .0
-            .lock()
-            .unwrap()
-            .replace(child);
-        }
-      });
+                let python_cmd = std::env::var("PYTHON_PATH").unwrap_or_else(|_| "python".into());
 
-      Ok(())
-    })
-    .build(tauri::generate_context!())
-    .expect("error while building tauri application")
-    .run(|app, event| {
-      if let RunEvent::Exit = event {
-        if let Some(child) = app.state::<BackendProcess>().0.lock().unwrap().as_mut() {
-          let _ = child.kill();
-        }
-      }
-    });
+                if which::which(&python_cmd).is_ok() {
+                    match Command::new(python_cmd).arg(script).spawn() {
+                        Ok(child) => {
+                            handle
+                                .state::<BackendProcess>()
+                                .0
+                                .lock()
+                                .unwrap()
+                                .replace(child);
+                        }
+                        Err(err) => {
+                            handle
+                                .dialog()
+                                .message(err.to_string())
+                                .title("Failed to start Python")
+                                .kind(MessageDialogKind::Error)
+                                .show(|_| {});
+                        }
+                    }
+                } else {
+                    handle
+                        .dialog()
+                        .message("Install Python or set the PYTHON_PATH environment variable.")
+                        .title("Python not found")
+                        .kind(MessageDialogKind::Error)
+                        .show(|_| {});
+                }
+            });
+
+            Ok(())
+        })
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|app, event| {
+            if let RunEvent::Exit = event {
+                if let Some(child) = app.state::<BackendProcess>().0.lock().unwrap().as_mut() {
+                    let _ = child.kill();
+                }
+            }
+        });
 }


### PR DESCRIPTION
## Summary
- ensure the app checks for a Python runtime before spawning the backend
- display an error dialog if Python is missing or fails to start
- add dialog and `which` dependencies

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689e36c7a6a883278ea4683163b0066f