### PR TITLE
Pin Python dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # macro_and_cal_tracker
 Tracking macros and calories in an easy-to-use app
 
+## Installation
+
+The backend dependencies are pinned in `requirements.txt` for reproducible
+environment setup. Install them with:
+
+```
+pip install -r requirements.txt
+```
+
 ## Environment Variables
 
 The frontend reads `VITE_API_BASE_URL` to know where to send API requests. If this

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-fastapi
-sqlmodel
-httpx
-python-dotenv
-platformdirs
-alembic
+fastapi==0.116.1
+sqlmodel==0.0.24
+httpx==0.28.1
+python-dotenv==1.1.1
+platformdirs==4.3.8
+alembic==1.16.4


### PR DESCRIPTION
## Summary
- pin unpinned Python packages in `requirements.txt`
- document dependency pinning and installation steps in the README

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e9ef4ab80832789a178ddb1ad6cb1