### PR TITLE
Configure CORS allowed origins via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ pip install -r requirements.txt
 
 ## Environment Variables
 
+### Frontend
+
 The frontend reads `VITE_API_BASE_URL` to know where to send API requests. If this
 variable is not set, the app falls back to `window.location.origin`.
 
@@ -30,6 +32,23 @@ VITE_API_BASE_URL=https://example.com
 ```
 
 Production builds use `npm run build` and desktop builds use `npm run build:desktop`.
+
+### Backend
+
+The API reads `ALLOWED_ORIGINS` to configure CORS. Provide a comma-separated list of allowed
+origins. If the variable is not set, all origins are allowed.
+
+For development, allow any origin:
+
+```
+export ALLOWED_ORIGINS=*
+```
+
+For production, specify the permitted domains:
+
+```
+export ALLOWED_ORIGINS=https://example.com,https://app.example.com
+```
 
 ## Keyboard Shortcuts
 

--- a/server/app.py
+++ b/server/app.py
@@ -1,6 +1,7 @@
 import asyncio
 from contextlib import asynccontextmanager
 from pathlib import Path
+import os
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -23,10 +24,16 @@ async def lifespan(app: FastAPI):
         pass
 
 
+allowed_origins_raw = os.getenv("ALLOWED_ORIGINS")
+if allowed_origins_raw:
+    allowed_origins = [origin.strip() for origin in allowed_origins_raw.split(",") if origin.strip()]
+else:
+    allowed_origins = ["*"]
+
 app = FastAPI(title="Macro Tracker API", lifespan=lifespan)
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- parse `ALLOWED_ORIGINS` env var into a list for CORS middleware
- document `ALLOWED_ORIGINS` for development and production

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f6ccb48c08327a9b3d57fc77537dc