### PR TITLE
Use logging for food fetch warnings and configure app logging

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -2,6 +2,7 @@ import asyncio
 from contextlib import asynccontextmanager
 from pathlib import Path
 import os
+import logging
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -10,6 +11,8 @@ from sqlmodel import SQLModel
 from server.db import get_engine
 from server.routers import foods, meals, presets, history, weight, config
 from server.run_migrations import run_migrations
+
+logging.basicConfig(level=logging.INFO)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):

--- a/server/routers/foods.py
+++ b/server/routers/foods.py
@@ -1,5 +1,6 @@
 from typing import Optional, List
 
+import logging
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Session, select, delete
@@ -9,6 +10,8 @@ from pydantic import BaseModel, field_validator
 from server.db import get_session
 from server.models import Food, FoodEntry, Favorite
 from server import utils
+
+logger = logging.getLogger(__name__)
 
 USDA_BASE = utils.USDA_BASE
 fetch_food_detail = utils.fetch_food_detail
@@ -63,7 +66,7 @@ async def foods_get(fdc_id: int, session: Session = Depends(get_session), refres
             abr = resp.json()[0]
         abr_fn = abr.get("foodNutrients") or []
     except Exception as e:
-        print(f"⚠️  Abridged fetch failed ({e}), falling back to full foodNutrients")
+        logger.warning("Abridged fetch failed (%s), falling back to full foodNutrients", e)
         abr_fn = []
     full_fn = data.get("foodNutrients") or []
     fn = abr_fn if abr_fn else full_fn


### PR DESCRIPTION
## Summary
- add module-level logger in foods router and swap print warning for logging
- configure root logging in app startup with INFO level

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fd2139da4832780c79e6b307a1c26