### PR TITLE
Handle date parameters as `date` objects

### DIFF
--- a/server/routers/history.py
+++ b/server/routers/history.py
@@ -21,9 +21,11 @@ def _scaled_from_food(f: Food, grams: float):
 
 
 @router.get("/api/history")
-def get_history(start_date: str, end_date: str, session: Session = Depends(get_session)):
+def get_history(start_date: date, end_date: date, session: Session = Depends(get_session)):
+    start_str = start_date.isoformat()
+    end_str = end_date.isoformat()
     meals = session.exec(
-        select(Meal).where(Meal.date >= start_date, Meal.date <= end_date)
+        select(Meal).where(Meal.date >= start_str, Meal.date <= end_str)
     ).all()
     meal_map = {m.id: m for m in meals}
     meal_ids = list(meal_map.keys())
@@ -43,7 +45,7 @@ def get_history(start_date: str, end_date: str, session: Session = Depends(get_s
 
     weights = session.exec(
         select(BodyWeight).where(
-            BodyWeight.date >= start_date, BodyWeight.date <= end_date
+            BodyWeight.date >= start_str, BodyWeight.date <= end_str
         )
     ).all()
     weight_map = {w.date: w.weight for w in weights}
@@ -65,11 +67,9 @@ def get_history(start_date: str, end_date: str, session: Session = Depends(get_s
         totals[day]["carb"] += c
         totals[day]["fat"] += fat
 
-    start = date.fromisoformat(start_date)
-    end = date.fromisoformat(end_date)
     out = []
-    cur = start
-    while cur <= end:
+    cur = start_date
+    while cur <= end_date:
         day = cur.isoformat()
         t = totals.get(day, {"kcal": 0.0, "protein": 0.0, "carb": 0.0, "fat": 0.0})
         out.append(

--- a/server/routers/presets.py
+++ b/server/routers/presets.py
@@ -1,4 +1,5 @@
 from typing import List
+from datetime import date
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Session, select, delete
@@ -21,11 +22,11 @@ class PresetCreate(BaseModel):
 
 class PresetFromMeal(BaseModel):
     name: str
-    date: str
+    date: date
     meal_name: str
 
 class PresetApply(BaseModel):
-    date: str
+    date: date
     meal_name: str
     multiplier: float | None = 1.0
 
@@ -71,7 +72,8 @@ def create_preset(payload: PresetCreate, session: Session = Depends(get_session)
 
 @router.post("/api/presets/from_meal")
 def create_preset_from_meal(payload: PresetFromMeal, session: Session = Depends(get_session)):
-    m = session.exec(select(Meal).where(Meal.date == payload.date, Meal.name == payload.meal_name)).first()
+    date_str = payload.date.isoformat()
+    m = session.exec(select(Meal).where(Meal.date == date_str, Meal.name == payload.meal_name)).first()
     if not m:
         raise HTTPException(status_code=404, detail="Meal not found")
     entries = session.exec(select(FoodEntry).where(FoodEntry.meal_id == m.id)).all()

--- a/server/routers/weight.py
+++ b/server/routers/weight.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from datetime import date
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
@@ -11,8 +11,9 @@ router = APIRouter()
 
 
 @router.get("/api/weight/{date}", response_model=BodyWeight)
-def get_weight(date: str, session: Session = Depends(get_session)):
-    weight = session.get(BodyWeight, date)
+def get_weight(date: date, session: Session = Depends(get_session)):
+    date_str = date.isoformat()
+    weight = session.get(BodyWeight, date_str)
     if not weight:
         raise HTTPException(status_code=404, detail="Weight not found")
     return weight
@@ -23,12 +24,13 @@ class WeightPayload(BaseModel):
 
 
 @router.put("/api/weight/{date}", response_model=BodyWeight)
-def set_weight(date: str, payload: WeightPayload, session: Session = Depends(get_session)):
-    weight_entry = session.get(BodyWeight, date)
+def set_weight(date: date, payload: WeightPayload, session: Session = Depends(get_session)):
+    date_str = date.isoformat()
+    weight_entry = session.get(BodyWeight, date_str)
     if weight_entry:
         weight_entry.weight = payload.weight
     else:
-        weight_entry = BodyWeight(date=date, weight=payload.weight)
+        weight_entry = BodyWeight(date=date_str, weight=payload.weight)
     session.add(weight_entry)
     session.commit()
     session.refresh(weight_entry)

--- a/server/tests/test_entry_crud.py
+++ b/server/tests/test_entry_crud.py
@@ -2,6 +2,7 @@ import os
 
 os.environ['USDA_KEY'] = 'test'
 
+from datetime import date
 from fastapi.testclient import TestClient
 from sqlmodel import SQLModel, Session, create_engine
 from sqlalchemy.pool import StaticPool
@@ -41,7 +42,7 @@ def test_entry_crud_flow():
                 carb_g_per_100g=5,
                 fat_g_per_100g=2,
             )
-            meal = Meal(date='2024-01-01', name='Meal 1', sort_order=1)
+            meal = Meal(date=date(2024, 1, 1).isoformat(), name='Meal 1', sort_order=1)
             session.add(food)
             session.add(meal)
             session.commit()
@@ -65,7 +66,8 @@ def test_entry_crud_flow():
         resp_move = client.patch(f'/api/entries/{entry_id2}', json={'sort_order': 1})
         assert resp_move.status_code == 200
 
-        resp3 = client.get('/api/days/2024-01-01')
+        day = date(2024, 1, 1).isoformat()
+        resp3 = client.get(f'/api/days/{day}')
         assert resp3.status_code == 200
         data = resp3.json()
         assert data['entries'][0]['id'] == entry_id2
@@ -76,7 +78,7 @@ def test_entry_crud_flow():
         resp4 = client.delete(f'/api/entries/{entry_id2}')
         assert resp4.status_code == 200
 
-        resp5 = client.get('/api/days/2024-01-01')
+        resp5 = client.get(f'/api/days/{day}')
         assert resp5.status_code == 200
         assert len(resp5.json()['entries']) == 1
         assert resp5.json()['totals'] == {'kcal': 150.0, 'protein': 15.0, 'carb': 7.5, 'fat': 3.0}
@@ -98,7 +100,7 @@ def test_negative_quantity_rejected():
                 carb_g_per_100g=5,
                 fat_g_per_100g=2,
             )
-            meal = Meal(date='2024-01-01', name='Meal 1', sort_order=1)
+            meal = Meal(date=date(2024, 1, 1).isoformat(), name='Meal 1', sort_order=1)
             session.add(food)
             session.add(meal)
             session.commit()

--- a/server/tests/test_history.py
+++ b/server/tests/test_history.py
@@ -2,6 +2,7 @@ import os
 
 os.environ['USDA_KEY'] = 'test'
 
+from datetime import date
 from fastapi.testclient import TestClient
 from sqlmodel import SQLModel, Session, create_engine
 from sqlalchemy.pool import StaticPool
@@ -42,19 +43,25 @@ def test_history_returns_macros_and_weight():
                 fat_g_per_100g=2,
             )
             session.add(food)
-            meal1 = Meal(date='2024-01-01', name='Meal 1', sort_order=1)
-            meal2 = Meal(date='2024-01-02', name='Meal 1', sort_order=1)
+            meal1 = Meal(date=date(2024, 1, 1).isoformat(), name='Meal 1', sort_order=1)
+            meal2 = Meal(date=date(2024, 1, 2).isoformat(), name='Meal 1', sort_order=1)
             session.add_all([meal1, meal2])
             session.commit()
             e1 = FoodEntry(meal_id=meal1.id, fdc_id=1, quantity_g=100, sort_order=1)
             e2 = FoodEntry(meal_id=meal2.id, fdc_id=1, quantity_g=200, sort_order=1)
             session.add_all([e1, e2])
-            w1 = BodyWeight(date='2024-01-01', weight=180)
-            w2 = BodyWeight(date='2024-01-02', weight=181)
+            w1 = BodyWeight(date=date(2024, 1, 1).isoformat(), weight=180)
+            w2 = BodyWeight(date=date(2024, 1, 2).isoformat(), weight=181)
             session.add_all([w1, w2])
             session.commit()
 
-        resp = client.get('/api/history', params={'start_date': '2024-01-01', 'end_date': '2024-01-02'})
+        resp = client.get(
+            '/api/history',
+            params={
+                'start_date': date(2024, 1, 1).isoformat(),
+                'end_date': date(2024, 1, 2).isoformat(),
+            },
+        )
         assert resp.status_code == 200
         data = resp.json()
         assert data == [

--- a/server/tests/test_meal_creation.py
+++ b/server/tests/test_meal_creation.py
@@ -2,6 +2,7 @@ import os
 
 os.environ['USDA_KEY'] = 'test'
 
+from datetime import date
 from fastapi.testclient import TestClient
 from sqlmodel import SQLModel, Session, create_engine
 from sqlalchemy.pool import StaticPool
@@ -32,13 +33,13 @@ def test_meal_creation_increments_sort_order():
     with TestClient(app.app) as client:
         SQLModel.metadata.create_all(engine)
 
-        resp1 = client.post('/api/meals', json={'date': '2024-01-01'})
+        resp1 = client.post('/api/meals', json={'date': date(2024, 1, 1).isoformat()})
         assert resp1.status_code == 200
         data1 = resp1.json()
         assert data1['sort_order'] == 1
         assert data1['name'] == 'Meal 1'
 
-        resp2 = client.post('/api/meals', json={'date': '2024-01-01'})
+        resp2 = client.post('/api/meals', json={'date': date(2024, 1, 1).isoformat()})
         assert resp2.status_code == 200
         data2 = resp2.json()
         assert data2['sort_order'] == 2

--- a/server/tests/test_presets.py
+++ b/server/tests/test_presets.py
@@ -2,6 +2,7 @@ import os
 
 os.environ['USDA_KEY'] = 'test'
 
+from datetime import date
 from fastapi.testclient import TestClient
 from sqlmodel import SQLModel, Session, create_engine
 from sqlalchemy.pool import StaticPool
@@ -55,10 +56,13 @@ def test_preset_create_and_apply():
         assert resp_detail.status_code == 200
         assert resp_detail.json()['items'][0]['fdc_id'] == 1
 
-        resp_apply = client.post(f'/api/presets/{preset_id}/apply', json={'date': '2024-01-01', 'meal_name': 'Meal 1'})
+        resp_apply = client.post(
+            f'/api/presets/{preset_id}/apply',
+            json={'date': date(2024, 1, 1).isoformat(), 'meal_name': 'Meal 1'}
+        )
         assert resp_apply.status_code == 200
         assert resp_apply.json()['added'] == 1
 
-        day = client.get('/api/days/2024-01-01')
+        day = client.get(f'/api/days/{date(2024, 1, 1).isoformat()}')
         assert day.status_code == 200
         assert len(day.json()['entries']) == 1

--- a/server/tests/test_weight.py
+++ b/server/tests/test_weight.py
@@ -2,6 +2,7 @@ import os
 
 os.environ['USDA_KEY'] = 'test'
 
+from datetime import date
 from fastapi.testclient import TestClient
 from sqlmodel import SQLModel, Session, create_engine
 from sqlalchemy.pool import StaticPool
@@ -32,11 +33,11 @@ def test_set_and_get_weight():
     with TestClient(app.app) as client:
         SQLModel.metadata.create_all(engine)
 
-        resp = client.put("/api/weight/2024-01-01", json={"weight": 180})
+        resp = client.put(f"/api/weight/{date(2024, 1, 1).isoformat()}", json={"weight": 180})
         assert resp.status_code == 200
         assert resp.json()["weight"] == 180
 
-        resp2 = client.get("/api/weight/2024-01-01")
+        resp2 = client.get(f"/api/weight/{date(2024, 1, 1).isoformat()}")
         assert resp2.status_code == 200
         assert resp2.json()["weight"] == 180
 
@@ -49,13 +50,13 @@ def test_update_weight_overwrites_previous():
     with TestClient(app.app) as client:
         SQLModel.metadata.create_all(engine)
 
-        resp = client.put("/api/weight/2024-01-01", json={"weight": 180})
+        resp = client.put(f"/api/weight/{date(2024, 1, 1).isoformat()}", json={"weight": 180})
         assert resp.status_code == 200
 
-        resp = client.put("/api/weight/2024-01-01", json={"weight": 182})
+        resp = client.put(f"/api/weight/{date(2024, 1, 1).isoformat()}", json={"weight": 182})
         assert resp.status_code == 200
 
-        resp2 = client.get("/api/weight/2024-01-01")
+        resp2 = client.get(f"/api/weight/{date(2024, 1, 1).isoformat()}")
         assert resp2.status_code == 200
         assert resp2.json()["weight"] == 182
 
@@ -68,5 +69,5 @@ def test_get_weight_not_found():
     with TestClient(app.app) as client:
         SQLModel.metadata.create_all(engine)
 
-        resp = client.get("/api/weight/2024-02-01")
+        resp = client.get(f"/api/weight/{date(2024, 2, 1).isoformat()}")
         assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- Switch API routes and models to use `date` instead of strings for day, meal, history, and weight operations
- Convert dates with `.isoformat()` when persisting or composing responses and filenames
- Update supporting utility and preset logic for `date` inputs and adjust tests to send ISO-formatted dates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fd2384c848327856a8981dc762360