### PR TITLE
feat: add interfaces for custom foods and offline cache

### DIFF
--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -78,3 +78,52 @@ export type Goals = {
   fat: number;
   carb: number;
 };
+
+export interface CustomFoodPayload {
+  description: string;
+  brand_owner?: string;
+  kcal_per_100g: number;
+  protein_g_per_100g: number;
+  carb_g_per_100g: number;
+  fat_g_per_100g: number;
+}
+
+export interface CopyMealPayload {
+  date: string;
+  meal_name: string;
+}
+
+export type CreateMealPayload = { date: string; tempId: number };
+export type DeleteMealPayload = { mealId: number };
+export type UpdateMealPayload = {
+  mealId: number;
+  data: { name?: string; sort_order?: number };
+};
+export type AddEntryPayload = {
+  meal_id: number;
+  fdc_id: number;
+  quantity_g: number;
+  tempId: number;
+};
+export type UpdateEntryPayload = { entryId: number; newGrams: number };
+export type MoveEntryPayload = { entryId: number; newOrder: number };
+export type DeleteEntryPayload = { entryId: number };
+export type SetWeightPayload = { date: string; weight: number };
+
+export type OfflineOp =
+  | { kind: "createMeal"; payload: CreateMealPayload }
+  | { kind: "deleteMeal"; payload: DeleteMealPayload }
+  | { kind: "updateMeal"; payload: UpdateMealPayload }
+  | { kind: "addEntry"; payload: AddEntryPayload }
+  | { kind: "updateEntry"; payload: UpdateEntryPayload }
+  | { kind: "moveEntry"; payload: MoveEntryPayload }
+  | { kind: "deleteEntry"; payload: DeleteEntryPayload }
+  | { kind: "setWeight"; payload: SetWeightPayload };
+
+export interface OfflineStore {
+  days: Record<string, DayFull>;
+  foods: SimpleFood[];
+  weights: Record<string, number>;
+  queue: OfflineOp[];
+  nextId: number;
+}


### PR DESCRIPTION
## Summary
- define interfaces for custom food payloads and offline queue store
- remove explicit `any` usage and update API to use typed payloads
- adapt paste-meal flow to new `CopyMealPayload`

## Testing
- `npm run lint` *(fails: Config at index 1 contains non-object extensions)*

------
https://chatgpt.com/codex/tasks/task_e_689fd2740fbc83279ba2f4473835272a