### PR TITLE
Add fetched_at cache timestamp for food items

### DIFF
--- a/alembic_migrations/versions/b7aa371b9a51_add_fetched_at_to_food.py
+++ b/alembic_migrations/versions/b7aa371b9a51_add_fetched_at_to_food.py
@@ -1,0 +1,30 @@
+"""Add fetched_at column to food
+
+Revision ID: b7aa371b9a51
+Revises: 16a51a1de3c0
+Create Date: 2024-09-17 00:00:00.000000
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+revision = "b7aa371b9a51"
+down_revision = "16a51a1de3c0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = inspect(bind)
+    if "fetched_at" not in [c["name"] for c in insp.get_columns("food")]:
+        op.add_column("food", sa.Column("fetched_at", sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = inspect(bind)
+    if "fetched_at" in [c["name"] for c in insp.get_columns("food")]:
+        op.drop_column("food", "fetched_at")

--- a/server/models.py
+++ b/server/models.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from datetime import datetime
 from sqlmodel import SQLModel, Field, Column
 from sqlalchemy import Boolean, UniqueConstraint
 
@@ -13,6 +14,7 @@ class Food(SQLModel, table=True):
     fat_g_per_100g: float
     carb_g_per_100g: float
     archived: bool = Field(default=False, sa_column=Column(Boolean, nullable=False, server_default="0"))
+    fetched_at: datetime = Field(default_factory=datetime.utcnow)
 
 class Meal(SQLModel, table=True):
     __table_args__ = (UniqueConstraint("date", "sort_order", name="uq_meal_date_sort_order"),)

--- a/server/tests/test_food_refresh.py
+++ b/server/tests/test_food_refresh.py
@@ -1,0 +1,85 @@
+import pytest
+from datetime import datetime, timedelta
+from sqlmodel import SQLModel, Session, create_engine
+from sqlalchemy.pool import StaticPool
+
+from server import db, utils
+from server.models import Food
+from server.utils import ensure_food_cached
+import asyncio
+
+
+def get_test_engine():
+    return create_engine('sqlite://', connect_args={'check_same_thread': False}, poolclass=StaticPool)
+
+
+def test_ensure_food_cached_uses_cache(monkeypatch):
+    engine = get_test_engine()
+    db.engine = engine
+    SQLModel.metadata.create_all(engine)
+    now = datetime.utcnow()
+    with Session(engine) as session:
+        food = Food(
+            fdc_id=1,
+            description='Old',
+            kcal_per_100g=50,
+            protein_g_per_100g=5,
+            fat_g_per_100g=1,
+            carb_g_per_100g=2,
+            fetched_at=now,
+        )
+        session.add(food)
+        session.commit()
+    called = False
+
+    async def fake_fetch(_):
+        nonlocal called
+        called = True
+        return {}
+
+    monkeypatch.setattr(utils, 'fetch_food_detail', fake_fetch)
+
+    with Session(engine) as session:
+        result = asyncio.run(ensure_food_cached(1, session))
+        assert result.fdc_id == 1
+        assert result.description == 'Old'
+    assert called is False
+
+
+def test_ensure_food_cached_refreshes_stale(monkeypatch):
+    engine = get_test_engine()
+    db.engine = engine
+    SQLModel.metadata.create_all(engine)
+    old_time = datetime.utcnow() - timedelta(days=60)
+    with Session(engine) as session:
+        food = Food(
+            fdc_id=2,
+            description='Old',
+            kcal_per_100g=10,
+            protein_g_per_100g=1,
+            fat_g_per_100g=1,
+            carb_g_per_100g=1,
+            fetched_at=old_time,
+        )
+        session.add(food)
+        session.commit()
+
+    async def new_fetch(_):
+        return {
+            'description': 'New',
+            'labelNutrients': {
+                'calories': {'value': 200},
+                'protein': {'value': 20},
+                'fat': {'value': 10},
+                'carbohydrates': {'value': 30},
+            },
+        }
+
+    monkeypatch.setattr(utils, 'fetch_food_detail', new_fetch)
+
+    with Session(engine) as session:
+        result = asyncio.run(ensure_food_cached(2, session))
+        assert result.description == 'New'
+        assert result.kcal_per_100g == 200
+        assert result.protein_g_per_100g == 20
+        assert result.fetched_at > old_time


### PR DESCRIPTION
## Summary
- track when food data is fetched from USDA with new `fetched_at` column
- refresh stale cached food (older than 30 days) before reuse
- cover fresh vs stale caching behavior with unit tests and migration

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fd6eb63108327a86ee65010adb3d9