### PR TITLE
Require token for config endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ For production, specify the permitted domains:
 export ALLOWED_ORIGINS=https://example.com,https://app.example.com
 ```
 
+Configuration endpoints require an authentication token. Set
+`CONFIG_AUTH_TOKEN` and include the same value in the `X-Config-Token`
+header when calling `/api/config/usda-key`:
+
+```
+export CONFIG_AUTH_TOKEN=secret-token
+curl -H "X-Config-Token: secret-token" http://localhost:8000/api/config/usda-key
+```
+
 ## Keyboard Shortcuts
 
 The application supports a few global shortcuts:

--- a/server/routers/config.py
+++ b/server/routers/config.py
@@ -1,19 +1,27 @@
-from fastapi import APIRouter, HTTPException
+import os
+
+from fastapi import APIRouter, Depends, Header, HTTPException
 from pydantic import BaseModel
 
 from server import utils
 
 router = APIRouter()
 
+
+def require_config_token(token: str = Header(..., alias="X-Config-Token")) -> None:
+    expected = os.environ.get("CONFIG_AUTH_TOKEN")
+    if not expected or token != expected:
+        raise HTTPException(status_code=401, detail="Invalid config token")
+
 @router.get("/api/config/usda-key")
-def get_usda_key():
+def get_usda_key(_: None = Depends(require_config_token)):
     return {"key": utils.USDA_KEY}
 
 class KeyPayload(BaseModel):
     key: str
 
 @router.post("/api/config/usda-key")
-def set_usda_key(payload: KeyPayload):
+def set_usda_key(payload: KeyPayload, _: None = Depends(require_config_token)):
     if not payload.key:
         raise HTTPException(status_code=400, detail="Key required")
     utils.update_usda_key(payload.key)


### PR DESCRIPTION
## Summary
- add simple header token check for config routes
- secure USDA key endpoints using CONFIG_AUTH_TOKEN
- document CONFIG_AUTH_TOKEN in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fd751a3548327af86e2f3a0f3684d