### PR TITLE
feat: add config auth token to frontend requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ export CONFIG_AUTH_TOKEN=secret-token
 curl -H "X-Config-Token: secret-token" http://localhost:8000/api/config/usda-key
 ```
 
+When building the frontend, expose the token as `VITE_CONFIG_AUTH_TOKEN` so
+requests automatically include the header:
+
+```
+VITE_CONFIG_AUTH_TOKEN=secret-token npm run build
+```
+
 ## Keyboard Shortcuts
 
 The application supports a few global shortcuts:

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -118,6 +118,11 @@ const api = axios.create({
   baseURL: `${inferredBase}/api`,
 });
 
+const configAuthToken = import.meta.env.VITE_CONFIG_AUTH_TOKEN;
+const configHeaders = configAuthToken
+  ? { "X-Config-Token": configAuthToken }
+  : undefined;
+
 class ApiError extends Error {
   constructor(message: string) {
     super(message);
@@ -395,12 +400,16 @@ export async function setWeight(date: string, weight: number) {
 
 // --- Configuration ---
 export async function getUsdaKey(): Promise<string | null> {
-  const response = await api.get("/config/usda-key");
+  const response = await api.get("/config/usda-key", { headers: configHeaders });
   return response.data.key || null;
 }
 
 export async function updateUsdaKey(key: string) {
-  const response = await api.post("/config/usda-key", { key });
+  const response = await api.post(
+    "/config/usda-key",
+    { key },
+    { headers: configHeaders }
+  );
   return response.data;
 }
 


### PR DESCRIPTION
## Summary
- include `X-Config-Token` header in frontend config requests
- document `VITE_CONFIG_AUTH_TOKEN` for builds

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fdc14b4e88327a3cd79c855e0fe77