### PR TITLE
Allow custom foods with unit-based servings

### DIFF
--- a/server/models.py
+++ b/server/models.py
@@ -13,6 +13,12 @@ class Food(SQLModel, table=True):
     protein_g_per_100g: float
     fat_g_per_100g: float
     carb_g_per_100g: float
+    # optional per-unit values for items not measured in grams
+    unit_name: Optional[str] = None
+    kcal_per_unit: Optional[float] = None
+    protein_g_per_unit: Optional[float] = None
+    carb_g_per_unit: Optional[float] = None
+    fat_g_per_unit: Optional[float] = None
     archived: bool = Field(default=False, sa_column=Column(Boolean, nullable=False, server_default="0"))
     fetched_at: datetime = Field(default_factory=datetime.utcnow)
 

--- a/server/routers/history.py
+++ b/server/routers/history.py
@@ -10,8 +10,16 @@ from server.models import Meal, FoodEntry, Food, BodyWeight
 router = APIRouter()
 
 
-def _scaled_from_food(f: Food, grams: float):
-    factor = (grams or 0) / 100.0
+def _scaled_from_food(f: Food, qty: float):
+    if f.unit_name:
+        factor = qty or 0
+        return (
+            (f.kcal_per_unit or 0) * factor,
+            (f.protein_g_per_unit or 0) * factor,
+            (f.carb_g_per_unit or 0) * factor,
+            (f.fat_g_per_unit or 0) * factor,
+        )
+    factor = (qty or 0) / 100.0
     return (
         (f.kcal_per_100g or 0) * factor,
         (f.protein_g_per_100g or 0) * factor,

--- a/server/tests/test_custom_units.py
+++ b/server/tests/test_custom_units.py
@@ -1,0 +1,61 @@
+from datetime import date
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, Session, create_engine
+from sqlalchemy.pool import StaticPool
+
+from server import app, db
+from server.models import Food, Meal
+
+
+def get_test_engine():
+    return create_engine(
+        'sqlite://',
+        connect_args={'check_same_thread': False},
+        poolclass=StaticPool,
+    )
+
+
+def override_get_session(engine):
+    def _get_session():
+        with Session(engine) as session:
+            yield session
+    return _get_session
+
+
+def test_custom_unit_food():
+    engine = get_test_engine()
+    db.engine = engine
+    app.app.dependency_overrides[db.get_session] = override_get_session(engine)
+
+    with TestClient(app.app) as client:
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as session:
+            food = Food(
+                fdc_id=-1,
+                description='Fish Oil',
+                data_type='Custom',
+                kcal_per_100g=0,
+                protein_g_per_100g=0,
+                carb_g_per_100g=0,
+                fat_g_per_100g=0,
+                unit_name='softgel',
+                kcal_per_unit=5,
+                protein_g_per_unit=0,
+                carb_g_per_unit=0,
+                fat_g_per_unit=0.5,
+            )
+            meal = Meal(date=date(2024, 1, 1).isoformat(), name='Meal 1', sort_order=1)
+            session.add(food)
+            session.add(meal)
+            session.commit()
+            meal_id = meal.id
+        resp = client.post('/api/entries', json={'meal_id': meal_id, 'fdc_id': -1, 'quantity_g': 2})
+        assert resp.status_code == 200
+        day_resp = client.get(f'/api/days/{date(2024, 1, 1).isoformat()}/full')
+        assert day_resp.status_code == 200
+        data = day_resp.json()
+        entry = data['meals'][0]['entries'][0]
+        assert entry['quantity_g'] == 2
+        assert entry['kcal'] == 10.0
+        assert entry['fat'] == 1.0
+        assert entry['unit_name'] == 'softgel'

--- a/web/src/components/DailyLog.tsx
+++ b/web/src/components/DailyLog.tsx
@@ -212,7 +212,7 @@ function MealCard({ meal, isCurrent, onSelect, onUpdateEntry, onDeleteEntry, onD
           <thead className="hidden sm:table-header-group">
             <tr className="border-b border-border-light dark:border-border-dark">
               <th className="text-left p-3 font-medium">Item</th>
-              <th className="text-right p-3 font-medium">Qty (g)</th>
+              <th className="text-right p-3 font-medium">Qty</th>
               <th className="text-right p-3 font-medium">kcal</th>
               <th className="text-right p-3 font-medium">F</th>
               <th className="text-right p-3 font-medium">C</th>
@@ -318,12 +318,12 @@ function Row({ e, onUpdate, onDelete, provided }: RowProps) {
     >
       <td className="p-2 text-left font-medium block sm:table-cell">{e.description}</td>
       <td className="p-2 flex items-center justify-between sm:table-cell sm:text-right">
-        <span className="sm:hidden mr-2">Qty (g)</span>
+        <span className="sm:hidden mr-2">{`Qty (${e.unit_name || 'g'})`}</span>
         {(() => {
           const id = `entry-${e.id}-qty`;
           return (
             <>
-              <label htmlFor={id} className="sr-only">Quantity in grams</label>
+              <label htmlFor={id} className="sr-only">Quantity in {e.unit_name || 'grams'}</label>
               <Input
                 id={id}
                 className="text-right w-20 py-1"

--- a/web/src/components/control-panel/CustomFoodTab.tsx
+++ b/web/src/components/control-panel/CustomFoodTab.tsx
@@ -12,6 +12,7 @@ function toSimpleFood(f: any): SimpleFood {
     fdcId: f.fdc_id ?? f.fdcId, description: f.description ?? "",
     brandOwner: f.brand_owner ?? f.brandOwner ?? undefined,
     dataType: f.data_type ?? f.dataType ?? undefined,
+    unit_name: f.unit_name ?? f.unitName ?? undefined,
   };
 }
 
@@ -20,6 +21,11 @@ type CustomFoodFormData = {
   kcal_per_100g: number | ''; protein_g_per_100g: number | ''; carb_g_per_100g: number | ''; fat_g_per_100g: number | '';
   labelKcal: number | ''; labelP: number | ''; labelC: number | ''; labelF: number | ''; servAmt: number | '';
   servUnit: LabelUnit; density: number | '';
+  unitName: string;
+  kcal_per_unit: number | '';
+  protein_g_per_unit: number | '';
+  carb_g_per_unit: number | '';
+  fat_g_per_unit: number | '';
 };
 
 export function CustomFoodTab() {
@@ -29,7 +35,8 @@ export function CustomFoodTab() {
     defaultValues: {
       density: 1, servUnit: 'g', description: '', brand_owner: '',
       kcal_per_100g: '', protein_g_per_100g: '', carb_g_per_100g: '', fat_g_per_100g: '',
-      labelKcal: '', labelP: '', labelC: '', labelF: '', servAmt: ''
+      labelKcal: '', labelP: '', labelC: '', labelF: '', servAmt: '',
+      unitName: '', kcal_per_unit: '', protein_g_per_unit: '', carb_g_per_unit: '', fat_g_per_unit: ''
     }
   });
   const [isCreatingFood, setIsCreatingFood] = useState(false);
@@ -46,6 +53,7 @@ export function CustomFoodTab() {
 
   const watchedConverterFields = watch(["labelKcal", "labelP", "labelC", "labelF", "servAmt", "servUnit", "density"]);
   const servUnit = watch("servUnit");
+  const unitName = watch("unitName");
 
   const labelPer100 = useMemo(() => {
     const [labelKcal, labelP, labelC, labelF, servAmt, servUnit, density] = watchedConverterFields;
@@ -68,7 +76,21 @@ export function CustomFoodTab() {
   const onCreateCustomFood = async (data: CustomFoodFormData) => {
     setIsCreatingFood(true);
     try {
-      const payload = { ...data, kcal_per_100g: Number(data.kcal_per_100g) || 0, protein_g_per_100g: Number(data.protein_g_per_100g) || 0, carb_g_per_100g: Number(data.carb_g_per_100g) || 0, fat_g_per_100g: Number(data.fat_g_per_100g) || 0 };
+      const payload: any = {
+        description: data.description,
+        brand_owner: data.brand_owner || undefined,
+        kcal_per_100g: Number(data.kcal_per_100g) || 0,
+        protein_g_per_100g: Number(data.protein_g_per_100g) || 0,
+        carb_g_per_100g: Number(data.carb_g_per_100g) || 0,
+        fat_g_per_100g: Number(data.fat_g_per_100g) || 0,
+      };
+      if (data.unitName) {
+        payload.unit_name = data.unitName;
+        payload.kcal_per_unit = Number(data.kcal_per_unit) || 0;
+        payload.protein_g_per_unit = Number(data.protein_g_per_unit) || 0;
+        payload.carb_g_per_unit = Number(data.carb_g_per_unit) || 0;
+        payload.fat_g_per_unit = Number(data.fat_g_per_unit) || 0;
+      }
       const created = await api.createCustomFood(payload);
       setAllMyFoods([toSimpleFood(created), ...allMyFoods]);
       reset();
@@ -94,6 +116,7 @@ export function CustomFoodTab() {
     protein: "cf-protein",
     fat: "cf-fat",
     carb: "cf-carb"
+    , unitName: "cf-unitName", kcalPerUnit: "cf-kcalUnit", proteinPerUnit: "cf-proteinUnit", carbPerUnit: "cf-carbUnit", fatPerUnit: "cf-fatUnit"
   } as const;
 
   return (
@@ -183,6 +206,30 @@ export function CustomFoodTab() {
             <Input id={ids.carb} type="number" step={0.01} placeholder="carb g" {...register('carb_g_per_100g', { required: true, valueAsNumber: true, min: 0 })} />
           </div>
         </div>
+        <div>
+          <label htmlFor={ids.unitName} className="sr-only">Unit name</label>
+          <Input id={ids.unitName} placeholder="Unit name (e.g., softgel)" {...register('unitName')} />
+        </div>
+        {unitName && (
+          <div className="grid grid-cols-2 gap-2">
+            <div className="flex flex-col">
+              <label htmlFor={ids.kcalPerUnit} className="sr-only">kcal per unit</label>
+              <Input id={ids.kcalPerUnit} type="number" step={0.01} placeholder="kcal / unit" {...register('kcal_per_unit', { valueAsNumber: true })} />
+            </div>
+            <div className="flex flex-col">
+              <label htmlFor={ids.proteinPerUnit} className="sr-only">protein g per unit</label>
+              <Input id={ids.proteinPerUnit} type="number" step={0.01} placeholder="protein g / unit" {...register('protein_g_per_unit', { valueAsNumber: true })} />
+            </div>
+            <div className="flex flex-col">
+              <label htmlFor={ids.fatPerUnit} className="sr-only">fat g per unit</label>
+              <Input id={ids.fatPerUnit} type="number" step={0.01} placeholder="fat g / unit" {...register('fat_g_per_unit', { valueAsNumber: true })} />
+            </div>
+            <div className="flex flex-col">
+              <label htmlFor={ids.carbPerUnit} className="sr-only">carb g per unit</label>
+              <Input id={ids.carbPerUnit} type="number" step={0.01} placeholder="carb g / unit" {...register('carb_g_per_unit', { valueAsNumber: true })} />
+            </div>
+          </div>
+        )}
         <div className="flex justify-end pt-2">
           <Button type="submit" className="btn-primary" disabled={isCreatingFood || !isValid}>
             {isCreatingFood ? 'Creating...' : 'Create Food'}

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -103,10 +103,24 @@ interface MacroFood {
   protein_g_per_100g?: number;
   carb_g_per_100g?: number;
   fat_g_per_100g?: number;
+  unit_name?: string;
+  kcal_per_unit?: number;
+  protein_g_per_unit?: number;
+  carb_g_per_unit?: number;
+  fat_g_per_unit?: number;
 }
 
-const macrosFromFood = (food: MacroFood, grams: number): MacroTotals => {
-  const f = grams / 100;
+const macrosFromFood = (food: MacroFood, amount: number): MacroTotals => {
+  if (food.unit_name) {
+    const f = amount;
+    return {
+      kcal: +((food.kcal_per_unit || 0) * f).toFixed(2),
+      protein: +((food.protein_g_per_unit || 0) * f).toFixed(2),
+      fat: +((food.fat_g_per_unit || 0) * f).toFixed(2),
+      carb: +((food.carb_g_per_unit || 0) * f).toFixed(2),
+    };
+  }
+  const f = amount / 100;
   return {
     kcal: +((food.kcal_per_100g || 0) * f).toFixed(2),
     protein: +((food.protein_g_per_100g || 0) * f).toFixed(2),
@@ -261,6 +275,7 @@ export const useStore = create<AppState & AppActions>((set, get) => ({
         carb: macros.carb,
         fat: macros.fat,
         sort_order: entryRes.sort_order,
+        unit_name: food.unit_name,
       };
       meal.entries.push(newEntry);
       meal.entries.sort((a, b) => a.sort_order - b.sort_order);

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -9,6 +9,7 @@ export type SimpleFood = {
   brandOwner?: string;
   dataType?: string;
   defaultGrams?: number;
+  unit_name?: string;
 };
 
 // --- MEAL & DAY ---
@@ -36,6 +37,7 @@ export interface EntryType {
   carb: number;
   fat: number;
   sort_order: number;
+  unit_name?: string;
 }
 
 // The full data structure for a day's meals and totals
@@ -82,10 +84,15 @@ export type Goals = {
 export interface CustomFoodPayload {
   description: string;
   brand_owner?: string;
-  kcal_per_100g: number;
-  protein_g_per_100g: number;
-  carb_g_per_100g: number;
-  fat_g_per_100g: number;
+  kcal_per_100g?: number;
+  protein_g_per_100g?: number;
+  carb_g_per_100g?: number;
+  fat_g_per_100g?: number;
+  unit_name?: string;
+  kcal_per_unit?: number;
+  protein_g_per_unit?: number;
+  carb_g_per_unit?: number;
+  fat_g_per_unit?: number;
 }
 
 export interface CopyMealPayload {


### PR DESCRIPTION
## Summary
- support custom foods that specify macros per unit instead of per 100g
- show unit names when logging entries and allow custom food creation with units
- compute macros correctly for unit-based entries

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fea35a434832795671d6681001e11