### PR TITLE
Fix custom food deletion query result handling

### DIFF
--- a/server/routers/foods.py
+++ b/server/routers/foods.py
@@ -342,9 +342,14 @@ def delete_custom_food(fdc_id: int, session: Session = Depends(get_session)):
         raise HTTPException(status_code=404, detail="Food not found.")
     if food.data_type != "Custom":
         raise HTTPException(status_code=400, detail="Only custom foods can be deleted here.")
-    cnt = session.exec(select(func.count()).select_from(FoodEntry).where(FoodEntry.fdc_id == fdc_id)).one()
-    if cnt and cnt[0] > 0:
-        raise HTTPException(status_code=409, detail="This food is used in logged entries. Remove it from logs first.")
+    cnt = session.exec(
+        select(func.count()).select_from(FoodEntry).where(FoodEntry.fdc_id == fdc_id)
+    ).one()
+    if cnt > 0:
+        raise HTTPException(
+            status_code=409,
+            detail="This food is used in logged entries. Remove it from logs first.",
+        )
     session.delete(food)
     session.commit()
     return {"ok": True}


### PR DESCRIPTION
## Summary
- fix custom food deletion to check count without subscripting result

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ff6b2f06c8327a3bcfa316ede9ca7