### PR TITLE
Fix entry reorder uniqueness errors

### DIFF
--- a/server/routers/meals.py
+++ b/server/routers/meals.py
@@ -5,7 +5,7 @@ import io
 
 from fastapi import APIRouter, Depends, HTTPException, Response, Query
 from sqlmodel import Session, select
-from sqlalchemy import func, delete
+from sqlalchemy import func, delete, desc
 from pydantic import BaseModel, field_validator
 
 from server.db import get_session
@@ -200,11 +200,12 @@ def update_entry(entry_id: int, payload: EntryUpdate, session: Session = Depends
                     FoodEntry.sort_order >= new_order,
                     FoodEntry.sort_order < old_order,
                 )
-                .order_by(FoodEntry.sort_order)
+                .order_by(desc(FoodEntry.sort_order))
             ).all()
             for item in affected:
                 item.sort_order += 1
                 session.add(item)
+                session.flush()
         elif new_order > old_order:
             affected = session.exec(
                 select(FoodEntry)
@@ -218,6 +219,7 @@ def update_entry(entry_id: int, payload: EntryUpdate, session: Session = Depends
             for item in affected:
                 item.sort_order -= 1
                 session.add(item)
+                session.flush()
         e.sort_order = new_order
     if payload.quantity_g is not None:
         e.quantity_g = float(payload.quantity_g)

--- a/server/tests/test_entry_crud.py
+++ b/server/tests/test_entry_crud.py
@@ -84,6 +84,82 @@ def test_entry_crud_flow():
         assert resp5.json()['totals'] == {'kcal': 150.0, 'protein': 15.0, 'carb': 7.5, 'fat': 3.0}
 
 
+def test_move_last_entry_to_top():
+    engine = get_test_engine()
+    db.engine = engine
+    app.app.dependency_overrides[db.get_session] = override_get_session(engine)
+
+    with TestClient(app.app) as client:
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as session:
+            food = Food(
+                fdc_id=1,
+                description='Test Food',
+                kcal_per_100g=100,
+                protein_g_per_100g=10,
+                carb_g_per_100g=5,
+                fat_g_per_100g=2,
+            )
+            meal = Meal(date=date(2024, 1, 1).isoformat(), name='Meal 1', sort_order=1)
+            session.add(food)
+            session.add(meal)
+            session.commit()
+            meal_id = meal.id
+
+        entry_ids = []
+        for qty in (100, 200, 300):
+            resp = client.post('/api/entries', json={'meal_id': meal_id, 'fdc_id': 1, 'quantity_g': qty})
+            assert resp.status_code == 200
+            entry_ids.append(resp.json()['id'])
+
+        resp_move = client.patch(f'/api/entries/{entry_ids[2]}', json={'sort_order': 1})
+        assert resp_move.status_code == 200
+
+        day = date(2024, 1, 1).isoformat()
+        resp_day = client.get(f'/api/days/{day}')
+        assert resp_day.status_code == 200
+        data = resp_day.json()
+        assert [e['id'] for e in data['entries']] == [entry_ids[2], entry_ids[0], entry_ids[1]]
+
+
+def test_move_first_entry_to_bottom():
+    engine = get_test_engine()
+    db.engine = engine
+    app.app.dependency_overrides[db.get_session] = override_get_session(engine)
+
+    with TestClient(app.app) as client:
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as session:
+            food = Food(
+                fdc_id=1,
+                description='Test Food',
+                kcal_per_100g=100,
+                protein_g_per_100g=10,
+                carb_g_per_100g=5,
+                fat_g_per_100g=2,
+            )
+            meal = Meal(date=date(2024, 1, 1).isoformat(), name='Meal 1', sort_order=1)
+            session.add(food)
+            session.add(meal)
+            session.commit()
+            meal_id = meal.id
+
+        entry_ids = []
+        for qty in (100, 200, 300):
+            resp = client.post('/api/entries', json={'meal_id': meal_id, 'fdc_id': 1, 'quantity_g': qty})
+            assert resp.status_code == 200
+            entry_ids.append(resp.json()['id'])
+
+        resp_move = client.patch(f'/api/entries/{entry_ids[0]}', json={'sort_order': 3})
+        assert resp_move.status_code == 200
+
+        day = date(2024, 1, 1).isoformat()
+        resp_day = client.get(f'/api/days/{day}')
+        assert resp_day.status_code == 200
+        data = resp_day.json()
+        assert [e['id'] for e in data['entries']] == [entry_ids[1], entry_ids[2], entry_ids[0]]
+
+
 def test_negative_quantity_rejected():
     engine = get_test_engine()
     db.engine = engine


### PR DESCRIPTION
## Summary
- prevent UNIQUE constraint failures when reordering meal entries
- add regression tests for moving entries across multiple positions

## Testing
- `pytest server/tests/test_entry_crud.py::test_move_last_entry_to_top -q`
- `pytest server/tests/test_entry_crud.py::test_move_first_entry_to_bottom -q`
- `pytest server/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68a009fb604c8327ac27660d2ce554af