### PR TITLE
Default export start date uses current day

### DIFF
--- a/web/src/components/control-panel/ExportTab.tsx
+++ b/web/src/components/control-panel/ExportTab.tsx
@@ -3,10 +3,15 @@ import toast from 'react-hot-toast';
 import * as api from "../../api";
 import { Button } from "../ui/Button";
 import { Input } from "../ui/Input";
+import { useStore } from "../../store";
 
 export function ExportTab() {
-  const [exportStart, setExportStart] = useState<string>(new Date().toISOString().slice(0, 10));
-  const [exportEnd, setExportEnd] = useState<string>(new Date().toISOString().slice(0, 10));
+  const today = new Date().toISOString().slice(0, 10);
+  const selectedDate = useStore(state => state.date);
+  const defaultStart = selectedDate > today ? today : selectedDate;
+
+  const [exportStart, setExportStart] = useState<string>(defaultStart);
+  const [exportEnd, setExportEnd] = useState<string>(today);
   const [isExporting, setIsExporting] = useState(false);
   const invalidRange = !exportStart || !exportEnd || exportStart > exportEnd;
 


### PR DESCRIPTION
## Summary
- default CSV export start date to the date currently selected by the user, but never after today

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0e13a8ad0832798d2e172d38089d8