### PR TITLE
Ensure export start date follows selected date

### DIFF
--- a/web/src/components/control-panel/ExportTab.tsx
+++ b/web/src/components/control-panel/ExportTab.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import toast from 'react-hot-toast';
 import * as api from "../../api";
 import { Button } from "../ui/Button";
@@ -13,6 +13,11 @@ export function ExportTab() {
   const [exportStart, setExportStart] = useState<string>(defaultStart);
   const [exportEnd, setExportEnd] = useState<string>(today);
   const [isExporting, setIsExporting] = useState(false);
+
+  useEffect(() => {
+    setExportStart(selectedDate > today ? today : selectedDate);
+  }, [selectedDate, today]);
+
   const invalidRange = !exportStart || !exportEnd || exportStart > exportEnd;
 
   async function handleExport() {


### PR DESCRIPTION
## Summary
- keep export start date in sync with the currently selected date

## Testing
- `npm test`
- `npm run lint` *(fails: Package subpath './config' is not defined by "exports" in eslint package)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0e278700c83279d90b8fb66c5bcd7