### PR TITLE
Surface USDA 503 errors in food search

### DIFF
--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -139,7 +139,16 @@ export async function searchFoods(query: string, dataType: string) {
     return response.data.results;
   } catch (err) {
     console.error("Failed to search foods:", err);
-    toast.error("Food search failed.");
+    if (axios.isAxiosError(err) && err.response?.status === 503) {
+      const detail = err.response.data?.detail;
+      toast.error(
+        typeof detail === "string"
+          ? detail
+          : "USDA search service unavailable. Please try again later."
+      );
+    } else {
+      toast.error("Food search failed.");
+    }
     return [];
   }
 }


### PR DESCRIPTION
## Summary
- provide clearer messaging when USDA food search returns a 503

## Testing
- `pytest`
- `cd web && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0e404c9dc8327940274062df89664