### PR TITLE
Prompt for quantity when quick-adding favorites

### DIFF
--- a/web/src/components/QuickAdd.tsx
+++ b/web/src/components/QuickAdd.tsx
@@ -5,13 +5,27 @@ export function QuickAdd() {
   const addFood = useStore(s => s.addFood);
   const favorites = useStore(s => s.favorites);
   if (!favorites.length) return null;
+
+  function handleClick(f: { fdcId: number; description: string; defaultGrams?: number }) {
+    const defaultAmount = f.defaultGrams ?? 100;
+    const input = window.prompt(
+      `How many grams of ${f.description}?`,
+      String(defaultAmount)
+    );
+    if (!input) return;
+    const grams = parseFloat(input);
+    if (!isNaN(grams) && grams > 0) {
+      addFood(f.fdcId, grams);
+    }
+  }
+
   return (
     <div className="flex flex-wrap gap-2 mb-4">
       {favorites.map(f => (
         <Button
           key={f.fdcId}
           className="btn-secondary btn-sm"
-          onClick={() => addFood(f.fdcId, f.defaultGrams ?? 100)}
+          onClick={() => handleClick(f)}
         >
           {f.description}
         </Button>

--- a/web/src/components/__tests__/QuickAdd.test.tsx
+++ b/web/src/components/__tests__/QuickAdd.test.tsx
@@ -28,10 +28,12 @@ describe('QuickAdd', () => {
     mockStore.favorites = [
       { fdcId: 1, description: 'Apple', defaultGrams: 150 },
     ];
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('175');
     render(<QuickAdd />);
     const btn = screen.getByRole('button', { name: /apple/i });
     fireEvent.click(btn);
-    expect(mockStore.addFood).toHaveBeenCalledWith(1, 150);
+    expect(mockStore.addFood).toHaveBeenCalledWith(1, 175);
+    promptSpy.mockRestore();
   });
 
   test('still triggers addFood when offline', () => {
@@ -39,9 +41,11 @@ describe('QuickAdd', () => {
     mockStore.favorites = [
       { fdcId: 2, description: 'Pear', defaultGrams: 100 },
     ];
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('120');
     render(<QuickAdd />);
     fireEvent.click(screen.getByRole('button', { name: /pear/i }));
-    expect(mockStore.addFood).toHaveBeenCalledWith(2, 100);
+    expect(mockStore.addFood).toHaveBeenCalledWith(2, 120);
+    promptSpy.mockRestore();
     Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
   });
 });


### PR DESCRIPTION
## Summary
- Ask user for desired grams before adding a favorited food
- Adjust QuickAdd tests for interactive prompt behavior

## Testing
- `cd web && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0e59cf85c83279a2cdbe8ca82c846