### PR TITLE
Fix totals not updating after entry deletion

### DIFF
--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -91,12 +91,22 @@ const loadFavorites = (): SimpleFood[] =>
 // --- Day mutation helpers -------------------------------------------------
 type MacroTotals = { kcal: number; protein: number; fat: number; carb: number };
 
-const applyDelta = (t: MacroTotals, d: MacroTotals) => {
-  t.kcal = +(t.kcal + d.kcal).toFixed(2);
-  t.protein = +(t.protein + d.protein).toFixed(2);
-  t.fat = +(t.fat + d.fat).toFixed(2);
-  t.carb = +(t.carb + d.carb).toFixed(2);
-};
+/**
+ * Apply a macro delta immutably.
+ *
+ * Zustand subscribers relying on object reference checks (the default
+ * behaviour) won't be notified if we mutate the existing totals object in
+ * place. This function returns a new object with the delta applied so that any
+ * part of the state tree referencing it receives a new reference and
+ * components such as the `Summary` card re-render when entries are removed or
+ * added.
+ */
+const applyDelta = (t: MacroTotals, d: MacroTotals): MacroTotals => ({
+  kcal: +(t.kcal + d.kcal).toFixed(2),
+  protein: +(t.protein + d.protein).toFixed(2),
+  fat: +(t.fat + d.fat).toFixed(2),
+  carb: +(t.carb + d.carb).toFixed(2),
+});
 
 interface MacroFood {
   kcal_per_100g?: number;
@@ -279,8 +289,8 @@ export const useStore = create<AppState & AppActions>((set, get) => ({
       };
       meal.entries.push(newEntry);
       meal.entries.sort((a, b) => a.sort_order - b.sort_order);
-      applyDelta(meal.subtotal, macros);
-      applyDelta(day.totals, macros);
+      meal.subtotal = applyDelta(meal.subtotal, macros);
+      day.totals = applyDelta(day.totals, macros);
       set({ day });
     } catch (e) {
       toast.error("Failed to add food entry.");
@@ -335,8 +345,8 @@ export const useStore = create<AppState & AppActions>((set, get) => ({
           entry.protein = newTotals.protein;
           entry.fat = newTotals.fat;
           entry.carb = newTotals.carb;
-          applyDelta(meal.subtotal, delta);
-          applyDelta(day.totals, delta);
+          meal.subtotal = applyDelta(meal.subtotal, delta);
+          day.totals = applyDelta(day.totals, delta);
           break;
         }
       }
@@ -374,8 +384,8 @@ export const useStore = create<AppState & AppActions>((set, get) => ({
           meal.entries.splice(idx, 1);
           meal.entries.forEach((e, i) => { e.sort_order = i + 1; });
           const delta = { kcal: -entry.kcal, protein: -entry.protein, fat: -entry.fat, carb: -entry.carb };
-          applyDelta(meal.subtotal, delta);
-          applyDelta(day.totals, delta);
+          meal.subtotal = applyDelta(meal.subtotal, delta);
+          day.totals = applyDelta(day.totals, delta);
           break;
         }
       }


### PR DESCRIPTION
## Summary
- Update store helper to immutably apply macro deltas
- Replace meal and day totals when entries are added, updated or deleted so Summary refreshes

## Testing
- `npm test --prefix web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0e6e79c888327a6df575a1a8cc0e2