### PR TITLE
feat: add undo/redo for meal entry deletions

### DIFF
--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -254,6 +254,7 @@ export async function addEntry(meal_id: number, fdc_id: number, quantity_g: numb
         carb: 0,
         fat: 0,
         sort_order: meal.entries.length,
+        fdc_id,
       };
       meal.entries.push(entry);
       cacheDay(day.date, day);

--- a/web/src/components/Hotkeys.tsx
+++ b/web/src/components/Hotkeys.tsx
@@ -6,6 +6,8 @@ export function Hotkeys() {
   const addMeal = useStore(s => s.addMeal);
   const toggleTheme = useStore(s => s.toggleTheme);
   const focusSearch = useStore(s => s.focusSearch);
+  const undo = useStore(s => s.undo);
+  const redo = useStore(s => s.redo);
   const [showHelp, setShowHelp] = useState(false);
 
   useEffect(() => {
@@ -25,7 +27,13 @@ export function Hotkeys() {
         return;
       }
       if (e.ctrlKey || e.metaKey) {
-        if (key === "m") {
+        if (!e.shiftKey && key === "z") {
+          e.preventDefault();
+          undo();
+        } else if ((e.shiftKey && key === "z") || key === "y") {
+          e.preventDefault();
+          redo();
+        } else if (key === "m") {
           e.preventDefault();
           addMeal();
         } else if (key === "f") {
@@ -59,6 +67,11 @@ export function Hotkeys() {
           <li><kbd className="px-1 py-0.5 rounded bg-border-light dark:bg-border-dark font-mono text-xs">Ctrl</kbd>+
               <kbd className="px-1 py-0.5 rounded bg-border-light dark:bg-border-dark font-mono text-xs">Shift</kbd>+
               <kbd className="px-1 py-0.5 rounded bg-border-light dark:bg-border-dark font-mono text-xs">L</kbd> Toggle theme</li>
+          <li><kbd className="px-1 py-0.5 rounded bg-border-light dark:bg-border-dark font-mono text-xs">Ctrl</kbd>+
+              <kbd className="px-1 py-0.5 rounded bg-border-light dark:bg-border-dark font-mono text-xs">Z</kbd> Undo delete</li>
+          <li><kbd className="px-1 py-0.5 rounded bg-border-light dark:bg-border-dark font-mono text-xs">Ctrl</kbd>+
+              <kbd className="px-1 py-0.5 rounded bg-border-light dark:bg-border-dark font-mono text-xs">Shift</kbd>+
+              <kbd className="px-1 py-0.5 rounded bg-border-light dark:bg-border-dark font-mono text-xs">Z</kbd> Redo delete</li>
           <li><kbd className="px-1 py-0.5 rounded bg-border-light dark:bg-border-dark font-mono text-xs">?</kbd> Toggle this help</li>
         </ul>
         <Button className="btn-primary mt-4" onClick={() => setShowHelp(false)}>Close</Button>

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -26,6 +26,10 @@ interface AppState {
   presets: Preset[];
   weight: number | null;
   goals: Goals;
+  /** Information about the most recently deleted entry for undo. */
+  lastDeleted: { mealId: number; entry: EntryType; index: number } | null;
+  /** Information about the last undone deletion for redo. */
+  redoDeleted: { mealId: number; entry: EntryType; index: number } | null;
 }
 
 interface AppActions {
@@ -41,6 +45,8 @@ interface AppActions {
   updateEntry: (entryId: number, grams: number) => Promise<void>;
   moveEntry: (entryId: number, newOrder: number) => Promise<void>;
   deleteEntry: (entryId: number) => Promise<void>;
+  undo: () => Promise<void>;
+  redo: () => Promise<void>;
   addMeal: () => Promise<void>;
   deleteMeal: (mealId: number) => Promise<void>;
   renameMeal: (mealId: number, newName: string) => Promise<void>;
@@ -152,6 +158,8 @@ export const useStore = create<AppState & AppActions>((set, get) => ({
   presets: [],
   weight: null,
   goals: getGoalsForDate(initialDate),
+  lastDeleted: null,
+  redoDeleted: null,
 
   copyMeal: (mealId: number) => {
     set({ copiedMealId: mealId });
@@ -275,6 +283,7 @@ export const useStore = create<AppState & AppActions>((set, get) => ({
         carb: macros.carb,
         fat: macros.fat,
         sort_order: entryRes.sort_order,
+        fdc_id: foodId,
         unit_name: food.unit_name,
       };
       meal.entries.push(newEntry);
@@ -367,6 +376,7 @@ export const useStore = create<AppState & AppActions>((set, get) => ({
     set((state) => {
       const day = state.day;
       if (!day) return {};
+      let deleted: { mealId: number; entry: EntryType; index: number } | null = null;
       for (const meal of day.meals) {
         const idx = meal.entries.findIndex(e => e.id === entryId);
         if (idx >= 0) {
@@ -376,10 +386,53 @@ export const useStore = create<AppState & AppActions>((set, get) => ({
           const delta = { kcal: -entry.kcal, protein: -entry.protein, fat: -entry.fat, carb: -entry.carb };
           applyDelta(meal.subtotal, delta);
           applyDelta(day.totals, delta);
+          deleted = { mealId: meal.id, entry, index: idx };
           break;
         }
       }
-      return { day };
+      return { day, lastDeleted: deleted, redoDeleted: null };
+    });
+  },
+
+  undo: async () => {
+    const info = get().lastDeleted;
+    if (!info) return;
+    const { mealId, entry, index } = info;
+    const res = await api.addEntry(mealId, entry.fdc_id || 0, entry.quantity_g);
+    set((state) => {
+      const day = state.day;
+      if (!day) return {};
+      const meal = day.meals.find(m => m.id === mealId);
+      if (!meal) return {};
+      const newEntry = { ...entry, id: res.id, sort_order: res.sort_order };
+      meal.entries.splice(index, 0, newEntry);
+      meal.entries.forEach((e, i) => { e.sort_order = i + 1; });
+      const delta = { kcal: entry.kcal, protein: entry.protein, fat: entry.fat, carb: entry.carb };
+      applyDelta(meal.subtotal, delta);
+      applyDelta(day.totals, delta);
+      return { day, lastDeleted: null, redoDeleted: { mealId, entry: newEntry, index } };
+    });
+  },
+
+  redo: async () => {
+    const info = get().redoDeleted;
+    if (!info) return;
+    const { mealId, entry, index } = info;
+    await api.deleteEntry(entry.id);
+    set((state) => {
+      const day = state.day;
+      if (!day) return {};
+      const meal = day.meals.find(m => m.id === mealId);
+      if (!meal) return {};
+      const idx = meal.entries.findIndex(e => e.id === entry.id);
+      if (idx >= 0) {
+        meal.entries.splice(idx, 1);
+        meal.entries.forEach((e, i) => { e.sort_order = i + 1; });
+        const delta = { kcal: -entry.kcal, protein: -entry.protein, fat: -entry.fat, carb: -entry.carb };
+        applyDelta(meal.subtotal, delta);
+        applyDelta(day.totals, delta);
+      }
+      return { day, lastDeleted: { mealId, entry, index }, redoDeleted: null };
     });
   },
   

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -37,6 +37,11 @@ export interface EntryType {
   carb: number;
   fat: number;
   sort_order: number;
+  /**
+   * Identifier of the underlying food item.  This is needed for actions like
+   * undoing a deletion where we must recreate the entry via the API.
+   */
+  fdc_id?: number;
   unit_name?: string;
 }
 


### PR DESCRIPTION
## Summary
- track food id on entries so deleted items can be restored
- manage last deleted entry and expose undo/redo actions in store
- add Ctrl+Z / Ctrl+Shift+Z shortcuts and help text for undo/redo

## Testing
- `npm test`
- `npm run lint` *(fails: Package subpath './config' is not defined by "exports" in eslint/package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e74c24bc8327bfcbf11014979805