### PR TITLE
docs: expand keyboard shortcuts in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ VITE_CONFIG_AUTH_TOKEN=secret-token npm run build
 The application supports a few global shortcuts:
 
 - `Ctrl+M` — add a new meal.
-- `Ctrl+F` — focus the food search box.
+- `Ctrl+F` or `/` — focus the food search box.
+- `Ctrl+Z` — undo the most recent delete.
+- `Ctrl+Shift+Z` or `Ctrl+Y` — redo the most recent delete.
 - `Ctrl+Shift+L` — toggle between light and dark themes.
 - `?` — show the in-app shortcuts help.
 


### PR DESCRIPTION
## Summary
- document additional keyboard shortcuts such as undo/redo and search via `/`

## Testing
- `pytest`
- `cd web && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0e9870d5c8327b6ad149621ac7493