### PR TITLE
refactor: centralize macro scaling

### DIFF
--- a/server/tests/test_scaled_macros.py
+++ b/server/tests/test_scaled_macros.py
@@ -1,0 +1,35 @@
+from server.models import Food
+from server.utils import scaled_macros_from_food
+
+
+def test_scaled_macros_from_food_per100g():
+    food = Food(
+        fdc_id=1,
+        description='Test Food',
+        data_type='Test',
+        kcal_per_100g=200,
+        protein_g_per_100g=10,
+        carb_g_per_100g=30,
+        fat_g_per_100g=5,
+    )
+    macros = scaled_macros_from_food(food, 50)
+    assert macros == (100.0, 5.0, 15.0, 2.5)
+
+
+def test_scaled_macros_from_food_unit():
+    food = Food(
+        fdc_id=2,
+        description='Unit Food',
+        data_type='Test',
+        kcal_per_100g=0,
+        protein_g_per_100g=0,
+        carb_g_per_100g=0,
+        fat_g_per_100g=0,
+        unit_name='piece',
+        kcal_per_unit=40,
+        protein_g_per_unit=2,
+        carb_g_per_unit=4,
+        fat_g_per_unit=1,
+    )
+    macros = scaled_macros_from_food(food, 3)
+    assert macros == (120.0, 6.0, 12.0, 3.0)

--- a/server/utils.py
+++ b/server/utils.py
@@ -223,6 +223,25 @@ async def ensure_food_cached(fdc_id: int, session: Session) -> Food:
     session.refresh(food)
     return food
 
+
+def scaled_macros_from_food(f: Food, qty: float) -> tuple[float, float, float, float]:
+    """Return kcal, protein, carb and fat scaled by quantity for a food item."""
+    if f.unit_name:
+        factor = qty or 0
+        return (
+            (f.kcal_per_unit or 0) * factor,
+            (f.protein_g_per_unit or 0) * factor,
+            (f.carb_g_per_unit or 0) * factor,
+            (f.fat_g_per_unit or 0) * factor,
+        )
+    factor = (qty or 0) / 100.0
+    return (
+        (f.kcal_per_100g or 0) * factor,
+        (f.protein_g_per_100g or 0) * factor,
+        (f.carb_g_per_100g or 0) * factor,
+        (f.fat_g_per_100g or 0) * factor,
+    )
+
 def get_or_create_meal(session: Session, date: date, name: str) -> Meal:
     date_str = date.isoformat()
     m = session.exec(select(Meal).where(Meal.date == date_str, Meal.name == name)).first()


### PR DESCRIPTION
## Summary
- centralize macro scaling logic in `server.utils.scaled_macros_from_food`
- update history and meal routers to use shared helper
- add tests for new macro scaling utility

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0ec0147948327801c080d35d3cb6c