### PR TITLE
reuse USDA AsyncClient for food fetches

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -11,6 +11,7 @@ from sqlmodel import SQLModel
 from server.db import get_engine
 from server.routers import foods, meals, presets, history, weight, config
 from server.run_migrations import run_migrations
+from server import utils
 
 logging.basicConfig(level=logging.INFO)
 
@@ -25,6 +26,8 @@ async def lifespan(app: FastAPI):
     except asyncio.CancelledError:
         # Swallow cancellation so reloads or Ctrl+C don't raise a stack trace
         pass
+    finally:
+        await utils.aclose_usda_client()
 
 
 allowed_origins_raw = os.getenv("ALLOWED_ORIGINS")

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -1,8 +1,19 @@
 import os
 import sys
 from pathlib import Path
+import asyncio
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 os.environ.setdefault("PYTHONPATH", str(ROOT))
+
+from server import utils
+
+
+@pytest.fixture(autouse=True)
+def close_usda_client():
+    yield
+    asyncio.run(utils.aclose_usda_client())


### PR DESCRIPTION
## Summary
- introduce lazily initialized USDA `AsyncClient`
- reuse shared client in `fetch_food_detail`
- close client during application shutdown
- add test fixture to close the shared client

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1029706d0832799ff113a35b47eb7