### PR TITLE
Clarify favorite quick add meal context and units

### DIFF
--- a/web/src/components/QuickAdd.tsx
+++ b/web/src/components/QuickAdd.tsx
@@ -1,21 +1,24 @@
 import { useStore } from "../store";
+import type { SimpleFood } from "../types";
 import { Button } from "./ui/Button";
 
 export function QuickAdd() {
   const addFood = useStore(s => s.addFood);
   const favorites = useStore(s => s.favorites);
+  const mealName = useStore(s => s.mealName);
   if (!favorites.length) return null;
 
-  function handleClick(f: { fdcId: number; description: string; defaultGrams?: number }) {
-    const defaultAmount = f.defaultGrams ?? 100;
+  function handleClick(f: SimpleFood) {
+    const unit = f.unit_name || "grams";
+    const defaultAmount = f.defaultGrams ?? (f.unit_name ? 1 : 100);
     const input = window.prompt(
-      `How many grams of ${f.description}?`,
+      `Add to ${mealName}: How many ${unit} of ${f.description}?`,
       String(defaultAmount)
     );
     if (!input) return;
-    const grams = parseFloat(input);
-    if (!isNaN(grams) && grams > 0) {
-      addFood(f.fdcId, grams);
+    const qty = parseFloat(input);
+    if (!isNaN(qty) && qty > 0) {
+      addFood(f.fdcId, qty);
     }
   }
 

--- a/web/src/components/__tests__/QuickAdd.test.tsx
+++ b/web/src/components/__tests__/QuickAdd.test.tsx
@@ -13,6 +13,7 @@ describe('QuickAdd', () => {
   beforeEach(() => {
     mockStore.favorites = [];
     mockStore.addFood = vi.fn();
+    mockStore.mealName = 'Breakfast';
   });
 
   afterEach(() => {
@@ -28,11 +29,32 @@ describe('QuickAdd', () => {
     mockStore.favorites = [
       { fdcId: 1, description: 'Apple', defaultGrams: 150 },
     ];
+    mockStore.mealName = 'Lunch';
     const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('175');
     render(<QuickAdd />);
     const btn = screen.getByRole('button', { name: /apple/i });
     fireEvent.click(btn);
+    expect(promptSpy).toHaveBeenCalledWith(
+      'Add to Lunch: How many grams of Apple?',
+      '150'
+    );
     expect(mockStore.addFood).toHaveBeenCalledWith(1, 175);
+    promptSpy.mockRestore();
+  });
+
+  test('uses custom unit in prompt', () => {
+    mockStore.favorites = [
+      { fdcId: 3, description: 'Fish Oil', unit_name: 'softgel', defaultGrams: 1 },
+    ];
+    mockStore.mealName = 'Dinner';
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('2');
+    render(<QuickAdd />);
+    fireEvent.click(screen.getByRole('button', { name: /fish oil/i }));
+    expect(promptSpy).toHaveBeenCalledWith(
+      'Add to Dinner: How many softgel of Fish Oil?',
+      '1'
+    );
+    expect(mockStore.addFood).toHaveBeenCalledWith(3, 2);
     promptSpy.mockRestore();
   });
 


### PR DESCRIPTION
## Summary
- Show meal name and appropriate unit when adding a favorite food
- Add tests for custom unit prompts

## Testing
- `npm test`
- `npm run lint` *(fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './config' is not defined by "exports" in eslint package)*

------
https://chatgpt.com/codex/tasks/task_e_68a10605954883279243c76c2b6930de