### PR TITLE
Fix Copy entry button overlapping Protein text

### DIFF
--- a/web/src/components/DailyLog.tsx
+++ b/web/src/components/DailyLog.tsx
@@ -246,7 +246,7 @@ function MealCard({ meal, isCurrent, onSelect, onUpdateEntry, onDeleteEntry, onD
             <col className="w-16" />
             <col className="w-16" />
             <col className="w-16" />
-            <col className="w-36" />
+            <col className="w-48" />
           </colgroup>
           <thead className="hidden sm:table-header-group">
             <tr className="border-b border-border-light dark:border-border-dark">


### PR DESCRIPTION
## Summary
- widen action column to accommodate Copy entry button

## Testing
- `npm test`
- `npm run lint` *(fails: Package subpath './config' not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a1090d1aa08327b5197acf2c2ec046