### PR TITLE
feat: custom quick add dialog

### DIFF
--- a/web/src/components/QuickAdd.tsx
+++ b/web/src/components/QuickAdd.tsx
@@ -1,38 +1,79 @@
+import { useState } from "react";
 import { useStore } from "../store";
 import type { SimpleFood } from "../types";
 import { Button } from "./ui/Button";
+import { Input } from "./ui/Input";
 
 export function QuickAdd() {
   const addFood = useStore(s => s.addFood);
   const favorites = useStore(s => s.favorites);
   const mealName = useStore(s => s.mealName);
+  const [current, setCurrent] = useState<SimpleFood | null>(null);
+  const [qty, setQty] = useState("0");
   if (!favorites.length) return null;
 
   function handleClick(f: SimpleFood) {
-    const unit = f.unit_name || "grams";
     const defaultAmount = f.defaultGrams ?? (f.unit_name ? 1 : 100);
-    const input = window.prompt(
-      `Add to ${mealName}: How many ${unit} of ${f.description}?`,
-      String(defaultAmount)
-    );
-    if (!input) return;
-    const qty = parseFloat(input);
-    if (!isNaN(qty) && qty > 0) {
-      addFood(f.fdcId, qty);
+    setQty(String(defaultAmount));
+    setCurrent(f);
+  }
+
+  function submit() {
+    if (!current) return;
+    const amount = parseFloat(qty);
+    if (!isNaN(amount) && amount > 0) {
+      addFood(current.fdcId, amount);
     }
+    setCurrent(null);
   }
 
   return (
-    <div className="flex flex-wrap gap-2 mb-4">
-      {favorites.map(f => (
-        <Button
-          key={f.fdcId}
-          className="btn-secondary btn-sm"
-          onClick={() => handleClick(f)}
+    <>
+      <div className="flex flex-wrap gap-2 mb-4">
+        {favorites.map(f => (
+          <Button
+            key={f.fdcId}
+            className="btn-secondary btn-sm"
+            onClick={() => handleClick(f)}
+          >
+            {f.description}
+          </Button>
+        ))}
+      </div>
+      {current && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          onClick={() => setCurrent(null)}
         >
-          {f.description}
-        </Button>
-      ))}
-    </div>
+          <div
+            className="bg-surface-light dark:bg-surface-dark rounded-md p-6 shadow-lg text-text dark:text-text-light"
+            onClick={e => e.stopPropagation()}
+            role="dialog"
+            aria-modal="true"
+          >
+            <p className="mb-4">
+              Add to <span className="font-semibold">{mealName}</span>: How many
+              <span className="font-semibold"> {current.unit_name || "grams"}</span>
+              {" "}of <span className="font-semibold">{current.description}</span>?
+            </p>
+            <Input
+              type="number"
+              value={qty}
+              onChange={e => setQty(e.currentTarget.value)}
+              className="w-full mb-4"
+              autoFocus
+            />
+            <div className="flex justify-end gap-2">
+              <Button className="btn-secondary" onClick={() => setCurrent(null)}>
+                Cancel
+              </Button>
+              <Button className="btn-primary" onClick={submit}>
+                OK
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   );
 }

--- a/web/src/components/__tests__/QuickAdd.test.tsx
+++ b/web/src/components/__tests__/QuickAdd.test.tsx
@@ -30,32 +30,30 @@ describe('QuickAdd', () => {
       { fdcId: 1, description: 'Apple', defaultGrams: 150 },
     ];
     mockStore.mealName = 'Lunch';
-    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('175');
     render(<QuickAdd />);
-    const btn = screen.getByRole('button', { name: /apple/i });
-    fireEvent.click(btn);
-    expect(promptSpy).toHaveBeenCalledWith(
-      'Add to Lunch: How many grams of Apple?',
-      '150'
-    );
+    fireEvent.click(screen.getByRole('button', { name: /apple/i }));
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveTextContent('Add to Lunch: How many grams of Apple?');
+    const input = screen.getByRole('spinbutton') as HTMLInputElement;
+    expect(input.value).toBe('150');
+    fireEvent.change(input, { target: { value: '175' } });
+    fireEvent.click(screen.getByRole('button', { name: /ok/i }));
     expect(mockStore.addFood).toHaveBeenCalledWith(1, 175);
-    promptSpy.mockRestore();
   });
 
-  test('uses custom unit in prompt', () => {
+  test('uses custom unit in dialog', () => {
     mockStore.favorites = [
       { fdcId: 3, description: 'Fish Oil', unit_name: 'softgel', defaultGrams: 1 },
     ];
     mockStore.mealName = 'Dinner';
-    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('2');
     render(<QuickAdd />);
     fireEvent.click(screen.getByRole('button', { name: /fish oil/i }));
-    expect(promptSpy).toHaveBeenCalledWith(
-      'Add to Dinner: How many softgel of Fish Oil?',
-      '1'
-    );
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveTextContent('Add to Dinner: How many softgel of Fish Oil?');
+    const input = screen.getByRole('spinbutton') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '2' } });
+    fireEvent.click(screen.getByRole('button', { name: /ok/i }));
     expect(mockStore.addFood).toHaveBeenCalledWith(3, 2);
-    promptSpy.mockRestore();
   });
 
   test('still triggers addFood when offline', () => {
@@ -63,11 +61,12 @@ describe('QuickAdd', () => {
     mockStore.favorites = [
       { fdcId: 2, description: 'Pear', defaultGrams: 100 },
     ];
-    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('120');
     render(<QuickAdd />);
     fireEvent.click(screen.getByRole('button', { name: /pear/i }));
+    const input = screen.getByRole('spinbutton') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '120' } });
+    fireEvent.click(screen.getByRole('button', { name: /ok/i }));
     expect(mockStore.addFood).toHaveBeenCalledWith(2, 120);
-    promptSpy.mockRestore();
     Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
   });
 });


### PR DESCRIPTION
## Summary
- replace browser prompt with custom QuickAdd dialog that highlights meal, unit, and item
- test QuickAdd modal behavior and unit handling

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1088ec04c83278b781eae2c1c69c0