### PR TITLE
Expose unit names for custom foods

### DIFF
--- a/server/routers/foods.py
+++ b/server/routers/foods.py
@@ -317,6 +317,7 @@ class CustomFoodSearchResult(BaseModel):
     description: str
     brand_owner: Optional[str] = Field(default=None, alias="brandOwner")
     data_type: Optional[str] = Field(default=None, alias="dataType")
+    unit_name: Optional[str] = None
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -365,6 +366,7 @@ def search_custom_foods(q: str, session: Session = Depends(get_session)):
             description=r.description,
             brand_owner=r.brand_owner,
             data_type=r.data_type,
+            unit_name=r.unit_name,
         )
         for r in rows
     ]
@@ -413,6 +415,7 @@ def my_foods(session: Session = Depends(get_session)):
             description=f.description,
             brand_owner=f.brand_owner,
             data_type=f.data_type or "Custom",
+            unit_name=f.unit_name,
         )
         for f in rows
     ]

--- a/server/tests/test_custom_foods.py
+++ b/server/tests/test_custom_foods.py
@@ -25,16 +25,18 @@ def test_create_and_search_custom_food():
         SQLModel.metadata.create_all(engine)
         payload = {
             'description': 'Test Food',
-            'kcal_per_100g': 100,
-            'protein_g_per_100g': 10,
-            'carb_g_per_100g': 5,
-            'fat_g_per_100g': 2,
+            'unit_name': 'pill',
+            'kcal_per_unit': 100,
+            'protein_g_per_unit': 10,
+            'carb_g_per_unit': 5,
+            'fat_g_per_unit': 2,
         }
         resp = client.post('/api/custom_foods', json=payload)
         assert resp.status_code == 200
         created = resp.json()
         assert created['description'] == 'Test Food'
-        assert created['kcal_per_100g'] == 100
+        assert created['unit_name'] == 'pill'
+        assert created['kcal_per_unit'] == 100
         assert 'fdc_id' in created
 
         resp_search = client.get('/api/custom_foods/search', params={'q': 'Test'})
@@ -44,9 +46,11 @@ def test_create_and_search_custom_food():
         assert results[0]['fdcId'] == created['fdc_id']
         assert results[0]['description'] == 'Test Food'
         assert results[0]['dataType'] == 'Custom'
+        assert results[0]['unit_name'] == 'pill'
 
         resp_my = client.get('/api/my_foods')
         assert resp_my.status_code == 200
         myfoods = resp_my.json()
         assert myfoods[0]['fdcId'] == created['fdc_id']
         assert myfoods[0]['description'] == 'Test Food'
+        assert myfoods[0]['unit_name'] == 'pill'


### PR DESCRIPTION
## Summary
- include `unit_name` in custom food search and list responses
- test custom food API to ensure unit names are preserved

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a10af06f288327829b2c50eccd9aef