### PR TITLE
fix: respect unit name in quick add dialog

### DIFF
--- a/web/src/components/QuickAdd.tsx
+++ b/web/src/components/QuickAdd.tsx
@@ -8,12 +8,16 @@ export function QuickAdd() {
   const addFood = useStore(s => s.addFood);
   const favorites = useStore(s => s.favorites);
   const mealName = useStore(s => s.mealName);
+  const allMyFoods = useStore(s => s.allMyFoods);
   const [current, setCurrent] = useState<SimpleFood | null>(null);
   const [qty, setQty] = useState("0");
   if (!favorites.length) return null;
 
   function handleClick(f: SimpleFood) {
-    const unit = f.unit_name || (f as any).unitName;
+    const unit =
+      f.unit_name ||
+      (f as any).unitName ||
+      allMyFoods.find(food => food.fdcId === f.fdcId)?.unit_name;
     const defaultAmount = f.defaultGrams ?? (unit ? 1 : 100);
     setQty(String(defaultAmount));
     setCurrent({ ...f, unit_name: unit });

--- a/web/src/components/__tests__/QuickAdd.test.tsx
+++ b/web/src/components/__tests__/QuickAdd.test.tsx
@@ -14,6 +14,7 @@ describe('QuickAdd', () => {
     mockStore.favorites = [];
     mockStore.addFood = vi.fn();
     mockStore.mealName = 'Breakfast';
+    mockStore.allMyFoods = [];
   });
 
   afterEach(() => {
@@ -55,6 +56,20 @@ describe('QuickAdd', () => {
     fireEvent.change(input, { target: { value: '2' } });
     fireEvent.click(screen.getByRole('button', { name: /ok/i }));
     expect(mockStore.addFood).toHaveBeenCalledWith(3, 2);
+  });
+
+  test('falls back to allMyFoods for unit', () => {
+    mockStore.allMyFoods = [
+      { fdcId: 4, description: 'Fish Oil', unit_name: 'softgel' },
+    ];
+    mockStore.favorites = [
+      { fdcId: 4, description: 'Fish Oil' },
+    ];
+    mockStore.mealName = 'Snack';
+    render(<QuickAdd />);
+    fireEvent.click(screen.getByRole('button', { name: /fish oil/i }));
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveTextContent('Add to Snack: How many softgel of Fish Oil?');
   });
 
   test('still triggers addFood when offline', () => {


### PR DESCRIPTION
## Summary
- ensure QuickAdd dialog uses unit info from favorites, legacy data, or allMyFoods
- test fallback when favorite lacks unit

## Testing
- `cd web && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a10e85cb988327a15892539dbda0ea