### PR TITLE
feat: add reusable modal component

### DIFF
--- a/web/src/components/QuickAdd.tsx
+++ b/web/src/components/QuickAdd.tsx
@@ -3,6 +3,7 @@ import { useStore } from "../store";
 import type { SimpleFood } from "../types";
 import { Button } from "./ui/Button";
 import { Input } from "./ui/Input";
+import { Modal } from "./ui/Modal";
 
 export function QuickAdd() {
   const addFood = useStore(s => s.addFood);
@@ -45,17 +46,9 @@ export function QuickAdd() {
           </Button>
         ))}
       </div>
-      {current && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-          onClick={() => setCurrent(null)}
-        >
-          <div
-            className="bg-surface-light dark:bg-surface-dark rounded-md p-6 shadow-lg text-text dark:text-text-light"
-            onClick={e => e.stopPropagation()}
-            role="dialog"
-            aria-modal="true"
-          >
+      <Modal open={!!current} onClose={() => setCurrent(null)}>
+        {current && (
+          <>
             <p className="mb-4">
               Add to <span className="font-semibold">{mealName}</span>: How many
               <span className="font-semibold"> {current.unit_name || "grams"}</span>
@@ -76,9 +69,9 @@ export function QuickAdd() {
                 OK
               </Button>
             </div>
-          </div>
-        </div>
-      )}
+          </>
+        )}
+      </Modal>
     </>
   );
 }

--- a/web/src/components/ui/Modal.tsx
+++ b/web/src/components/ui/Modal.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState, type ReactNode } from "react";
+
+interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  children: ReactNode;
+}
+
+export function Modal({ open, onClose, children }: ModalProps) {
+  const [show, setShow] = useState(open);
+
+  // handle mount/unmount for close animation
+  useEffect(() => {
+    if (open) {
+      setShow(true);
+      return;
+    }
+    const t = setTimeout(() => setShow(false), 200);
+    return () => clearTimeout(t);
+  }, [open]);
+
+  // keyboard dismissal
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    }
+    if (open) {
+      document.addEventListener("keydown", handleKey);
+      return () => document.removeEventListener("keydown", handleKey);
+    }
+  }, [open, onClose]);
+
+  if (!show) return null;
+
+  return (
+    <div
+      className={`fixed inset-0 z-50 flex items-center justify-center bg-black/50 transition-opacity duration-200 ${open ? "opacity-100" : "opacity-0 pointer-events-none"}`}
+      onClick={onClose}
+    >
+      <div
+        className={`bg-surface-light dark:bg-surface-dark rounded-md p-6 shadow-lg text-text dark:text-text-light transition-transform duration-200 ${open ? "scale-100" : "scale-95"}`}
+        role="dialog"
+        aria-modal="true"
+        onClick={e => e.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export default Modal;


### PR DESCRIPTION
## Summary
- create reusable `<Modal>` component with overlay, accessibility, keyboard dismissal and transition animations
- refactor `QuickAdd` to use `<Modal>` for its dialog

## Testing
- `npm test`
- `npm run lint` *(fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './config' is not defined by "exports" in eslint/package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a110edd6688327b269dd604f4dc43b