### PR TITLE
Constrain layout content width

### DIFF
--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -128,7 +128,7 @@ export function Layout({ children }: LayoutProps) {
         </div>
       </div>
 
-      <main className="mx-auto px-4 py-6 lg:px-6">{children}</main>
+      <main className="mx-auto max-w-screen-lg px-4 py-6 lg:px-6">{children}</main>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add `max-w-screen-lg` to main layout container for consistent width

## Testing
- `npm test`
- `npm run lint` *(fails: Package subpath './config' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a1130d3ebc832797cb2d8ea7879176