### PR TITLE
fix: restore desktop layout width

### DIFF
--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -127,8 +127,7 @@ export function Layout({ children }: LayoutProps) {
           </nav>
         </div>
       </div>
-
-      <main className="mx-auto max-w-screen-lg px-4 py-6 lg:px-6">{children}</main>
+      <main className="mx-auto px-4 py-6 lg:px-6">{children}</main>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- remove overly restrictive main content width

## Testing
- `npm --prefix web test`
- `npm --prefix web run lint` *(fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED])*


------
https://chatgpt.com/codex/tasks/task_e_68a11444f7d4832785478fb8637793de