### PR TITLE
feat: configurable radial progress text color

### DIFF
--- a/web/src/components/RadialProgress.tsx
+++ b/web/src/components/RadialProgress.tsx
@@ -6,9 +6,10 @@ interface RadialProgressProps {
     color: string; // tailwind color class for stroke
     decimals?: number;
     unit?: string;
+    textColor?: string;
 }
 
-export function RadialProgress({ value, goal, color, decimals = 0, unit = "" }: RadialProgressProps) {
+export function RadialProgress({ value, goal, color, decimals = 0, unit = "", textColor }: RadialProgressProps) {
     const pct = goal > 0 ? Math.min(100, (value / goal) * 100) : 0;
     const radius = 28;
     const circumference = 2 * Math.PI * radius;
@@ -49,7 +50,9 @@ export function RadialProgress({ value, goal, color, decimals = 0, unit = "" }: 
                         <span className="sr-only">Goal exceeded</span>
                     </div>
                 )}
-                <div className="absolute inset-0 flex items-center justify-center text-sm font-bold text-text dark:text-text-light">
+                <div
+                    className={`absolute inset-0 flex items-center justify-center text-sm font-bold ${textColor ?? "text-text dark:text-text-light"}`}
+                >
                     {value.toFixed(decimals)}{unit}
                 </div>
             </div>

--- a/web/src/components/Summary.tsx
+++ b/web/src/components/Summary.tsx
@@ -25,7 +25,7 @@ export function Summary() {
                         {/* kcal */}
                         <div className="flex-1 bg-brand-primary/10 dark:bg-brand-primary/30 p-3 rounded-lg text-center transition-shadow hover:shadow-md">
                             <div className="text-sm text-brand-primary dark:text-brand-primary mb-2">kcal</div>
-                            <RadialProgress value={totals?.kcal ?? 0} goal={goals.kcal} color="text-brand-primary" decimals={0} />
+                            <RadialProgress value={totals?.kcal ?? 0} goal={goals.kcal} color="text-brand-primary" decimals={0} textColor="text-brand-primary" />
                         </div>
 
                         {/* fat */}


### PR DESCRIPTION
## Summary
- allow RadialProgress to accept optional textColor prop
- display kcal total with high-contrast brand text color

## Testing
- `cd web && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a117db5a488327843c13e7696f94bb