### PR TITLE
feat: allow resizing radial progress value

### DIFF
--- a/web/src/components/RadialProgress.tsx
+++ b/web/src/components/RadialProgress.tsx
@@ -7,9 +7,10 @@ interface RadialProgressProps {
     decimals?: number;
     unit?: string;
     textColor?: string;
+    valueClassName?: string;
 }
 
-export function RadialProgress({ value, goal, color, decimals = 0, unit = "", textColor }: RadialProgressProps) {
+export function RadialProgress({ value, goal, color, decimals = 0, unit = "", textColor, valueClassName }: RadialProgressProps) {
     const pct = goal > 0 ? Math.min(100, (value / goal) * 100) : 0;
     const radius = 28;
     const circumference = 2 * Math.PI * radius;
@@ -51,7 +52,7 @@ export function RadialProgress({ value, goal, color, decimals = 0, unit = "", te
                     </div>
                 )}
                 <div
-                    className={`absolute inset-0 flex items-center justify-center text-sm font-bold ${textColor ?? "text-text dark:text-text-light"}`}
+                    className={`absolute inset-0 flex items-center justify-center font-bold ${valueClassName ?? "text-sm"} ${textColor ?? "text-text dark:text-text-light"}`}
                 >
                     {value.toFixed(decimals)}{unit}
                 </div>

--- a/web/src/components/Summary.tsx
+++ b/web/src/components/Summary.tsx
@@ -25,25 +25,25 @@ export function Summary() {
                         {/* kcal */}
                         <div className="flex-1 bg-brand-primary/10 dark:bg-brand-primary/30 p-3 rounded-lg text-center transition-shadow hover:shadow-md">
                             <div className="text-sm text-brand-primary dark:text-brand-primary mb-2">kcal</div>
-                            <RadialProgress value={totals?.kcal ?? 0} goal={goals.kcal} color="text-brand-primary" decimals={0} textColor="text-brand-primary" />
+                            <RadialProgress value={totals?.kcal ?? 0} goal={goals.kcal} color="text-brand-primary" decimals={0} textColor="text-brand-primary" valueClassName="text-base" />
                         </div>
 
                         {/* fat */}
                         <div className="flex-1 bg-brand-warning/10 dark:bg-brand-warning/30 p-3 rounded-lg text-center transition-shadow hover:shadow-md">
                             <div className="text-sm text-brand-warning dark:text-brand-warning mb-2">Fat</div>
-                            <RadialProgress value={totals?.fat ?? 0} goal={goals.fat} color="text-brand-warning" decimals={1} unit="g" />
+                            <RadialProgress value={totals?.fat ?? 0} goal={goals.fat} color="text-brand-warning" decimals={1} unit="g" valueClassName="text-base" />
                         </div>
 
                         {/* carb */}
                         <div className="flex-1 bg-brand-danger/10 dark:bg-brand-danger/30 p-3 rounded-lg text-center transition-shadow hover:shadow-md">
                             <div className="text-sm text-brand-danger dark:text-brand-danger mb-2">Carb</div>
-                            <RadialProgress value={totals?.carb ?? 0} goal={goals.carb} color="text-brand-danger" decimals={1} unit="g" />
+                            <RadialProgress value={totals?.carb ?? 0} goal={goals.carb} color="text-brand-danger" decimals={1} unit="g" valueClassName="text-base" />
                         </div>
 
                         {/* protein */}
                         <div className="flex-1 bg-brand-success/10 dark:bg-brand-success/30 p-3 rounded-lg text-center transition-shadow hover:shadow-md">
                             <div className="text-sm text-brand-success dark:text-brand-success mb-2">Protein</div>
-                            <RadialProgress value={totals?.protein ?? 0} goal={goals.protein} color="text-brand-success" decimals={1} unit="g" />
+                            <RadialProgress value={totals?.protein ?? 0} goal={goals.protein} color="text-brand-success" decimals={1} unit="g" valueClassName="text-base" />
                         </div>
                     </div>
                     <div className="mt-6">


### PR DESCRIPTION
## Summary
- allow RadialProgress to accept optional value class
- bump radial progress value text size in summary for better readability

## Testing
- `npm test`
- `npm run lint` *(fails: tseslint.config(): Config at index 1 contains non-object extensions)*

------
https://chatgpt.com/codex/tasks/task_e_68a1190a32748327b673c53fa277877d