### PR TITLE
Replace DailyLog emoji with Heroicons

### DIFF
--- a/web/src/components/DailyLog.tsx
+++ b/web/src/components/DailyLog.tsx
@@ -7,6 +7,7 @@ import { useStore } from "../store";
 import type { MealType, EntryType } from "../types";
 import { Button } from "./ui/Button";
 import { Input } from "./ui/Input";
+import { PencilSquareIcon, TrashIcon } from "@heroicons/react/24/outline";
 
 export function DailyLog() {
   const {
@@ -212,7 +213,7 @@ function MealCard({ meal, isCurrent, onSelect, onUpdateEntry, onDeleteEntry, onD
               onClick={(e) => { e.stopPropagation(); setIsRenaming(true); }}
               className="btn-ghost btn-sm"
             >
-              ✏️
+              <PencilSquareIcon className="h-4 w-4" />
             </Button>
             <Button
               type="button"
@@ -231,7 +232,7 @@ function MealCard({ meal, isCurrent, onSelect, onUpdateEntry, onDeleteEntry, onD
                 onClick={(e) => { e.stopPropagation(); onDeleteMeal(meal.id); }}
                 className="btn-ghost btn-sm"
               >
-                🗑️
+                <TrashIcon className="h-4 w-4" />
               </Button>
             )}
         </div>


### PR DESCRIPTION
## Summary
- import Heroicons outline icons
- use PencilSquareIcon and TrashIcon instead of emoji in DailyLog buttons

## Testing
- `npm test`
- `npm run lint` *(fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED])*


------
https://chatgpt.com/codex/tasks/task_e_68a13133c5c08327aaeb31180061d5cd