### PR TITLE
Improve kcal contrast in dark mode

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -24,7 +24,7 @@
 }
 
 .dark {
-  --color-brand-primary: 79 70 229;
+  --color-brand-primary: 129 140 248;
   --color-brand-success: 130 202 157;
   --color-brand-warning: 255 198 88;
   --color-brand-danger: 255 128 66;

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -27,11 +27,11 @@ const palettes = {
         tooltipBg: '#333',
         tooltipColor: '#fff',
         lines: {
-            kcal: '#8884d8',
+            kcal: '#a5b4fc',
             protein: '#82ca9d',
             fat: '#ffc658',
             carb: '#ff8042',
-            weight: '#8884d8',
+            weight: '#a5b4fc',
         },
     },
 } as const;


### PR DESCRIPTION
## Summary
- Brighten dark theme brand color for better kcal visibility
- Lighten Dashboard kcal and weight line colors in dark mode

## Testing
- `npm test`
- `npm run lint` *(fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED])* 
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1347a9d088327b9794e1e3500a470