### PR TITLE
Add tooltip for Unbranded first search option

### DIFF
--- a/web/src/components/SearchBar.tsx
+++ b/web/src/components/SearchBar.tsx
@@ -177,6 +177,7 @@ export function SearchBar() {
             className="rounded text-brand-primary focus:ring-brand-primary"
             checked={unbrandedFirst}
             onChange={(e) => setUnbrandedFirst(e.target.checked)}
+            title="Show unbranded foods first"
           />
           <label htmlFor={idUnbranded} className="cursor-pointer">Unbranded first</label>
         </div>

--- a/web/src/components/__tests__/SearchBar.test.tsx
+++ b/web/src/components/__tests__/SearchBar.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen, cleanup } from '@testing-library/react';
+import { beforeEach, afterEach, describe, expect, test, vi } from 'vitest';
+
+const mockStore: any = {};
+vi.mock('../../store', () => ({
+  useStore: (selector?: any) => selector ? selector(mockStore) : mockStore,
+}));
+
+import { SearchBar } from '../SearchBar';
+
+describe('SearchBar', () => {
+  beforeEach(() => {
+    mockStore.mealName = 'Breakfast';
+    mockStore.allMyFoods = [];
+    mockStore.setAllMyFoods = vi.fn();
+    mockStore.addFood = vi.fn();
+    mockStore.favorites = [];
+    mockStore.toggleFavorite = vi.fn();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('shows tooltip for Unbranded first', () => {
+    render(<SearchBar />);
+    const checkbox = screen.getByLabelText('Unbranded first');
+    expect(checkbox).toHaveAttribute('title', 'Show unbranded foods first');
+  });
+});


### PR DESCRIPTION
## Summary
- add missing tooltip to the `Unbranded first` checkbox in the search bar
- test that the tooltip attribute is present

## Testing
- `npm test --prefix web`


------
https://chatgpt.com/codex/tasks/task_e_68a137b3faf08327bca00ce6fe3ce607