### PR TITLE
Add CI pipeline for backend, frontend and Tauri builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,79 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install flake8 pytest
+      - name: Lint
+        run: flake8 server
+      - name: Run tests
+        run: pytest --junitxml=pytest-results.xml
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-test-results
+          path: pytest-results.xml
+
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+      - name: Install dependencies
+        working-directory: web
+        run: npm ci
+      - name: Lint
+        working-directory: web
+        run: npm run lint
+      - name: Run tests
+        working-directory: web
+        run: npm test -- --reporter=junit --outputFile=vitest-results.xml
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-test-results
+          path: web/vitest-results.xml
+
+  tauri:
+    runs-on: ubuntu-latest
+    needs: [backend, frontend]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+      - name: Install frontend dependencies
+        working-directory: web
+        run: npm ci
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Build Tauri app
+        working-directory: web
+        run: |
+          npm run build:desktop
+          npx tauri build
+      - name: Upload bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: tauri-bundle
+          path: |
+            web/src-tauri/target/release/bundle


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run backend and frontend tests & linting
- build Tauri application and upload artifacts

## Testing
- `pytest`
- `flake8 server` (fails: E302 expected 2 blank lines)
- `npm run lint` (fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED])
- `npm test -- --reporter=junit --outputFile=vitest-results.xml`
- `npm run build:desktop` (fails: TS18048: 'meal' is possibly 'undefined')
- `npx tauri build` (fails: You must change the bundle identifier in `tauri.conf.json identifier`)


------
https://chatgpt.com/codex/tasks/task_e_68a1399e7f908327a99c7722088f2bd0