### PR TITLE
fix: update ESLint config for flat config

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -3,16 +3,20 @@ import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
-import { globalIgnores } from 'eslint/config'
 
 export default tseslint.config([
-  globalIgnores(['dist']),
   {
+    ignores: ['dist'],
     files: ['**/*.{ts,tsx}'],
+    plugins: {
+      'react-hooks': reactHooks,
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+    },
     extends: [
       js.configs.recommended,
-      tseslint.configs.recommended,
-      reactHooks.configs['recommended-latest'],
+      ...tseslint.configs.recommended,
       reactRefresh.configs.vite,
     ],
     languageOptions: {


### PR DESCRIPTION
## Summary
- migrate web eslint config away from `eslint/config`
- register React Hooks plugin and spread TypeScript config

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any & other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a13b232a10832797afaa8c7c00c552