### PR TITLE
feat: add cache retention with timestamps

### DIFF
--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -51,8 +51,11 @@ beforeEach(async () => {
 test('failed API call requeues operation and preserves queue length', async () => {
   const initialStore = {
     days: {},
+    dayTimestamps: {},
     foods: [],
+    foodsTimestamp: 0,
     weights: {},
+    weightTimestamps: {},
     queue: [{ kind: 'createMeal', payload: { date: '2024-01-01', tempId: -1 } }],
     nextId: -1,
   };

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -134,8 +134,11 @@ export type OfflineOp =
 
 export interface OfflineStore {
   days: Record<string, DayFull>;
+  dayTimestamps: Record<string, number>;
   foods: SimpleFood[];
+  foodsTimestamp: number;
   weights: Record<string, number>;
+  weightTimestamps: Record<string, number>;
   queue: OfflineOp[];
   nextId: number;
 }


### PR DESCRIPTION
## Summary
- add configurable retention constants for offline cache
- timestamp cached days, foods, and weights
- purge outdated or excess cached entries on load

## Testing
- `npm test --prefix web`
- `npm run lint --prefix web` *(fails: Package subpath './config' is not defined by "exports" in eslint package)*

------
https://chatgpt.com/codex/tasks/task_e_68a13d1778608327849e9c91af83569d