### PR TITLE
Improve config loading error handling

### DIFF
--- a/server/utils.py
+++ b/server/utils.py
@@ -43,12 +43,16 @@ CONFIG_PATH = Path(
 )
 
 
-def _load_config() -> Dict:
+def _load_config() -> Optional[Dict]:
     try:
         with open(CONFIG_PATH, "r", encoding="utf-8") as f:
             return json.load(f)
-    except Exception:
-        return {}
+    except OSError as exc:
+        logger.warning("Failed to load config %s: %s", CONFIG_PATH, exc)
+        return None
+    except json.JSONDecodeError as exc:
+        logger.warning("Invalid JSON in config %s: %s", CONFIG_PATH, exc)
+        raise
 
 
 def _save_config(cfg: Dict) -> None:
@@ -57,7 +61,7 @@ def _save_config(cfg: Dict) -> None:
         json.dump(cfg, f)
 
 
-_config = _load_config()
+_config = _load_config() or {}
 
 # USDA_KEY is loaded from config file first, then environment
 USDA_KEY = _config.get("usda_key") or os.getenv("USDA_KEY")


### PR DESCRIPTION
## Summary
- Narrow `_load_config` exception handling to `OSError` and `json.JSONDecodeError`
- Log configuration load failures and re-raise invalid JSON errors
- Default to empty config when the file is missing or unreadable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a359b6902883279b277e2cd640dfa6