### PR TITLE
Use UUID-based IDs for custom foods

### DIFF
--- a/server/routers/foods.py
+++ b/server/routers/foods.py
@@ -1,5 +1,6 @@
 import logging
 from typing import List, Optional
+from uuid import uuid4
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
@@ -367,9 +368,8 @@ class CustomFoodSearchResult(BaseModel):
 def create_custom_food(body: CustomFoodIn, session: Session = Depends(get_session)):
     desc = body.description.strip()
     brand = (body.brand_owner or "").strip() or None
-    import time
-
-    fdc_id = -int(time.time() * 1000)
+    # Use a UUID-based negative ID to avoid collisions with USDA records.
+    fdc_id = -(uuid4().int & ((1 << 63) - 1))
     f = Food(
         fdc_id=fdc_id,
         description=desc,


### PR DESCRIPTION
## Summary
- Generate custom food IDs from UUIDs instead of timestamps to avoid collisions
- Update tests to create custom foods via API so IDs are dynamic

## Testing
- `pre-commit run --files server/routers/foods.py server/tests/test_custom_units.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a359c980d48327834b09f40365e1a0