### PR TITLE
Use Pydantic models for day summaries

### DIFF
--- a/server/tests/test_copy_meal.py
+++ b/server/tests/test_copy_meal.py
@@ -10,6 +10,7 @@ from sqlmodel import Session, SQLModel, create_engine
 
 from server import app, db
 from server.models import Food, FoodEntry, Meal
+from server.routers.meals import DaySummary
 
 
 def get_test_engine():
@@ -81,6 +82,6 @@ def test_copy_meal_assigns_sort_order():
         day = date(2024, 1, 2).isoformat()
         resp_day = client.get(f"/api/days/{day}")
         assert resp_day.status_code == 200
-        data = resp_day.json()
-        dest_entries = [e for e in data["entries"] if e["meal_id"] == dest_meal_id]
-        assert [e["sort_order"] for e in dest_entries] == [1, 2, 3]
+        data = DaySummary.model_validate(resp_day.json())
+        dest_entries = [e for e in data.entries if e.meal_id == dest_meal_id]
+        assert [e.sort_order for e in dest_entries] == [1, 2, 3]

--- a/server/tests/test_presets.py
+++ b/server/tests/test_presets.py
@@ -10,6 +10,7 @@ from sqlmodel import Session, SQLModel, create_engine
 
 from server import app, db
 from server.models import Food
+from server.routers.meals import DaySummary
 
 
 def get_test_engine():
@@ -72,4 +73,5 @@ def test_preset_create_and_apply():
 
         day = client.get(f"/api/days/{date(2024, 1, 1).isoformat()}")
         assert day.status_code == 200
-        assert len(day.json()["entries"]) == 1
+        data = DaySummary.model_validate(day.json())
+        assert len(data.entries) == 1


### PR DESCRIPTION
## Summary
- Add `DayTotals` and `DaySummary` Pydantic models
- Return `DaySummary` from `/api/days/{date}` endpoint
- Update tests to validate responses with new models

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a35dbd89f08327810da36f57cbb21f