### PR TITLE
Handle unexpected errors in _to_float

### DIFF
--- a/server/tests/test_utils_to_float.py
+++ b/server/tests/test_utils_to_float.py
@@ -1,0 +1,25 @@
+import logging
+import pytest
+
+from server.utils import _to_float
+
+
+def test_to_float_valid():
+    assert _to_float("1.23") == 1.23
+    assert _to_float(5) == 5.0
+
+
+def test_to_float_invalid_returns_zero():
+    assert _to_float("abc") == 0.0
+    assert _to_float(None) == 0.0
+
+
+def test_to_float_unexpected_exception_logs_and_raises(caplog):
+    class Boom:
+        def __float__(self):
+            raise RuntimeError("boom")
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(RuntimeError):
+            _to_float(Boom())
+    assert "Unexpected error converting" in caplog.text

--- a/server/utils.py
+++ b/server/utils.py
@@ -98,8 +98,11 @@ def update_usda_key(new_key: str) -> None:
 def _to_float(x):
     try:
         return float(x)
-    except Exception:
+    except (ValueError, TypeError):
         return 0.0
+    except Exception:
+        logger.exception("Unexpected error converting %r to float", x)
+        raise
 
 
 class MacroTotals(TypedDict):


### PR DESCRIPTION
## Summary
- Raise or log unexpected errors when converting to float
- Test float conversions including invalid and unexpected inputs

## Testing
- `pytest server/tests/test_utils_to_float.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a360bfbfc4832797e5012f0dfa88e0