### PR TITLE
feat: allow archiving custom foods

### DIFF
--- a/server/tests/test_custom_foods.py
+++ b/server/tests/test_custom_foods.py
@@ -57,3 +57,49 @@ def test_create_and_search_custom_food():
         assert myfoods[0]["fdcId"] == created["fdc_id"]
         assert myfoods[0]["description"] == "Test Food"
         assert myfoods[0]["unit_name"] == "pill"
+
+
+def test_archive_custom_food():
+    engine = get_test_engine()
+    db.engine = engine
+    app.app.dependency_overrides[db.get_session] = override_get_session(engine)
+
+    with TestClient(app.app) as client:
+        SQLModel.metadata.create_all(engine)
+        payload = {
+            "description": "Temp Food",
+            "kcal_per_100g": 100,
+            "protein_g_per_100g": 10,
+            "carb_g_per_100g": 20,
+            "fat_g_per_100g": 5,
+        }
+        resp = client.post("/api/custom_foods", json=payload)
+        assert resp.status_code == 200
+        fdc_id = resp.json()["fdc_id"]
+
+        meal = client.post("/api/meals", json={"date": "2024-01-01"}).json()
+        client.post(
+            "/api/entries",
+            json={"meal_id": meal["id"], "fdc_id": fdc_id, "quantity_g": 50},
+        )
+
+        recents = client.get("/api/recents").json()["items"]
+        assert any(r["fdc_id"] == fdc_id for r in recents)
+
+        del_resp = client.delete(f"/api/custom_foods/{fdc_id}")
+        assert del_resp.status_code == 409
+
+        arch = client.patch(f"/api/custom_foods/{fdc_id}", json={"archived": True})
+        assert arch.status_code == 200
+
+        myfoods = client.get("/api/my_foods").json()
+        assert myfoods == []
+
+        search = client.get("/api/custom_foods/search", params={"q": "Temp"}).json()
+        assert search == []
+
+        recents_after = client.get("/api/recents").json()["items"]
+        assert all(r["fdc_id"] != fdc_id for r in recents_after)
+
+        resp_get = client.get(f"/api/foods/{fdc_id}")
+        assert resp_get.status_code == 404

--- a/server/tests/test_utils_to_float.py
+++ b/server/tests/test_utils_to_float.py
@@ -1,4 +1,5 @@
 import logging
+
 import pytest
 
 from server.utils import _to_float
@@ -19,7 +20,7 @@ def test_to_float_unexpected_exception_logs_and_raises(caplog):
         def __float__(self):
             raise RuntimeError("boom")
 
-    with caplog.at_level(logging.ERROR):
+    with caplog.at_level(logging.ERROR, logger="server.utils"):
         with pytest.raises(RuntimeError):
             _to_float(Boom())
     assert "Unexpected error converting" in caplog.text

--- a/server/utils.py
+++ b/server/utils.py
@@ -101,7 +101,7 @@ def _to_float(x):
     except (ValueError, TypeError):
         return 0.0
     except Exception:
-        logger.exception("Unexpected error converting %r to float", x)
+        logging.exception("Unexpected error converting %r to float", x)
         raise
 
 

--- a/web/src/api/foods.ts
+++ b/web/src/api/foods.ts
@@ -56,6 +56,13 @@ export async function deleteCustomFood(foodId: number) {
   return response.data;
 }
 
+export async function archiveCustomFood(foodId: number) {
+  const response = await api.patch(`/custom_foods/${foodId}`, {
+    archived: true,
+  });
+  return response.data;
+}
+
 export async function getUsdaKey(): Promise<string | null> {
   const response = await api.get("/config/usda-key", {
     headers: configHeaders,

--- a/web/src/components/SearchBar.tsx
+++ b/web/src/components/SearchBar.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import toast from "react-hot-toast";
 import { useStore } from "../store";
-import { searchFoods, deleteCustomFood } from "../api/foods";
+import { searchFoods, deleteCustomFood, archiveCustomFood } from "../api/foods";
 import { DATA_TYPE_OPTIONS } from "../types";
 import type { DataTypeOpt, SimpleFood } from "../types";
 import { Button } from "./ui/Button";
@@ -140,7 +140,21 @@ export function SearchBar() {
       setAllMyFoods(allMyFoods.filter((food) => food.fdcId !== foodId));
       toast.success("Custom food deleted.");
     } catch (e: any) {
-      toast.error(e?.response?.data?.detail || "Could not delete food.");
+      if (e?.response?.status === 409) {
+        if (confirm("Food is used in logs. Archive instead?")) {
+          try {
+            await archiveCustomFood(foodId);
+            setAllMyFoods(allMyFoods.filter((food) => food.fdcId !== foodId));
+            toast.success("Custom food archived.");
+          } catch (err: any) {
+            toast.error(
+              err?.response?.data?.detail || "Could not archive food.",
+            );
+          }
+        }
+      } else {
+        toast.error(e?.response?.data?.detail || "Could not delete food.");
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- allow custom foods to be marked archived
- hide archived foods from favorites and recents
- archive custom foods from UI when deletion fails

## Testing
- `pre-commit run --files server/utils.py server/tests/test_utils_to_float.py server/routers/foods.py server/tests/test_custom_foods.py web/src/api/foods.ts web/src/components/SearchBar.tsx`
- `pytest`
- `cd web && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a362b909908327b483d1384aedcf35