### PR TITLE
Add water intake tracking

### DIFF
--- a/alembic_migrations/versions/8e7a06648fd2_create_waterintake_table.py
+++ b/alembic_migrations/versions/8e7a06648fd2_create_waterintake_table.py
@@ -1,0 +1,35 @@
+"""Create waterintake table
+
+Revision ID: 8e7a06648fd2
+Revises: b7aa371b9a51
+Create Date: 2024-09-18 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+
+revision = "8e7a06648fd2"
+down_revision = "b7aa371b9a51"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = inspect(bind)
+    if "waterintake" not in insp.get_table_names():
+        op.create_table(
+            "waterintake",
+            sa.Column("date", sa.String(), primary_key=True),
+            sa.Column("milliliters", sa.Float(), nullable=False),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = inspect(bind)
+    if "waterintake" in insp.get_table_names():
+        op.drop_table("waterintake")

--- a/server/app.py
+++ b/server/app.py
@@ -10,7 +10,7 @@ from sqlmodel import SQLModel
 
 from server import utils
 from server.db import get_engine
-from server.routers import config, foods, history, meals, presets, weight
+from server.routers import config, foods, history, meals, presets, weight, water
 from server.run_migrations import run_migrations
 
 logging.basicConfig(level=logging.INFO)
@@ -53,4 +53,5 @@ app.include_router(meals.router)
 app.include_router(presets.router)
 app.include_router(history.router)
 app.include_router(weight.router)
+app.include_router(water.router)
 app.include_router(config.router)

--- a/server/models.py
+++ b/server/models.py
@@ -69,3 +69,8 @@ class PresetItem(SQLModel, table=True):
 class BodyWeight(SQLModel, table=True):
     date: str = Field(primary_key=True)
     weight: float
+
+
+class WaterIntake(SQLModel, table=True):
+    date: str = Field(primary_key=True)
+    milliliters: float

--- a/server/routers/__init__.py
+++ b/server/routers/__init__.py
@@ -1,3 +1,3 @@
-from server.routers import config, foods, history, meals, presets, weight
+from server.routers import config, foods, history, meals, presets, weight, water
 
-__all__ = ["foods", "meals", "presets", "history", "weight", "config"]
+__all__ = ["foods", "meals", "presets", "history", "weight", "water", "config"]

--- a/server/routers/water.py
+++ b/server/routers/water.py
@@ -1,0 +1,39 @@
+from datetime import date
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlmodel import Session
+
+from server.db import get_session
+from server.models import WaterIntake
+
+router = APIRouter()
+
+
+@router.get("/api/water/{date}", response_model=WaterIntake)
+def get_water(date: date, session: Session = Depends(get_session)):
+    date_str = date.isoformat()
+    water = session.get(WaterIntake, date_str)
+    if not water:
+        raise HTTPException(status_code=404, detail="Water intake not found")
+    return water
+
+
+class WaterPayload(BaseModel):
+    milliliters: float
+
+
+@router.put("/api/water/{date}", response_model=WaterIntake)
+def set_water(
+    date: date, payload: WaterPayload, session: Session = Depends(get_session)
+):
+    date_str = date.isoformat()
+    water_entry = session.get(WaterIntake, date_str)
+    if water_entry:
+        water_entry.milliliters = payload.milliliters
+    else:
+        water_entry = WaterIntake(date=date_str, milliliters=payload.milliliters)
+    session.add(water_entry)
+    session.commit()
+    session.refresh(water_entry)
+    return water_entry

--- a/server/tests/test_water.py
+++ b/server/tests/test_water.py
@@ -1,0 +1,84 @@
+import os
+
+os.environ["USDA_KEY"] = "test"
+
+from datetime import date
+
+from fastapi.testclient import TestClient
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, SQLModel, create_engine
+
+from server import app, db
+
+
+def get_test_engine():
+    return create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+
+def override_get_session(engine):
+    def _get_session():
+        with Session(engine) as session:
+            yield session
+
+    return _get_session
+
+
+def test_set_and_get_water():
+    engine = get_test_engine()
+    db.engine = engine
+    app.app.dependency_overrides[db.get_session] = override_get_session(engine)
+
+    with TestClient(app.app) as client:
+        SQLModel.metadata.create_all(engine)
+
+        resp = client.put(
+            f"/api/water/{date(2024, 1, 1).isoformat()}",
+            json={"milliliters": 500},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["milliliters"] == 500
+
+        resp2 = client.get(f"/api/water/{date(2024, 1, 1).isoformat()}")
+        assert resp2.status_code == 200
+        assert resp2.json()["milliliters"] == 500
+
+
+def test_update_water_overwrites_previous():
+    engine = get_test_engine()
+    db.engine = engine
+    app.app.dependency_overrides[db.get_session] = override_get_session(engine)
+
+    with TestClient(app.app) as client:
+        SQLModel.metadata.create_all(engine)
+
+        resp = client.put(
+            f"/api/water/{date(2024, 1, 1).isoformat()}",
+            json={"milliliters": 500},
+        )
+        assert resp.status_code == 200
+
+        resp = client.put(
+            f"/api/water/{date(2024, 1, 1).isoformat()}",
+            json={"milliliters": 750},
+        )
+        assert resp.status_code == 200
+
+        resp2 = client.get(f"/api/water/{date(2024, 1, 1).isoformat()}")
+        assert resp2.status_code == 200
+        assert resp2.json()["milliliters"] == 750
+
+
+def test_get_water_not_found():
+    engine = get_test_engine()
+    db.engine = engine
+    app.app.dependency_overrides[db.get_session] = override_get_session(engine)
+
+    with TestClient(app.app) as client:
+        SQLModel.metadata.create_all(engine)
+
+        resp = client.get(f"/api/water/{date(2024, 2, 1).isoformat()}")
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- add WaterIntake model for tracking daily water consumption
- expose GET/PUT /api/water/{date} endpoints
- create Alembic migration for waterintake table and include router in app

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3ef3cce4083278b6c49519c57f128