### PR TITLE
feat: add water tracking with offline support

### DIFF
--- a/web/src/api/meals.ts
+++ b/web/src/api/meals.ts
@@ -14,6 +14,8 @@ import {
   cacheDay,
   cacheWeight,
   getCachedWeight,
+  cacheWater,
+  getCachedWater,
   nextTempId,
   enqueue,
 } from "./offline";
@@ -267,5 +269,30 @@ export async function setWeight(date: string, weight: number) {
     return { weight };
   }
   const response = await api.put(`/weight/${date}`, { weight });
+  return response.data;
+}
+
+export async function getWater(date: string) {
+  if (!isOnline()) {
+    const w = getCachedWater(date);
+    return w !== undefined ? { milliliters: w } : null;
+  }
+  try {
+    const response = await api.get(`/water/${date}`);
+    if (response.data?.milliliters !== undefined)
+      cacheWater(date, response.data.milliliters);
+    return response.data;
+  } catch {
+    return null;
+  }
+}
+
+export async function setWater(date: string, milliliters: number) {
+  if (!isOnline()) {
+    cacheWater(date, milliliters);
+    enqueue({ kind: "setWater", payload: { date, milliliters } });
+    return { milliliters };
+  }
+  const response = await api.put(`/water/${date}`, { milliliters });
   return response.data;
 }

--- a/web/src/api/offline.ts
+++ b/web/src/api/offline.ts
@@ -18,6 +18,8 @@ const defaultStore: OfflineStore = {
   foodsTimestamp: 0,
   weights: {},
   weightTimestamps: {},
+  water: {},
+  waterTimestamps: {},
   queue: [],
   nextId: -1,
 };
@@ -59,6 +61,23 @@ function purgeStore(store: OfflineStore) {
     }
   }
 
+  for (const date of Object.keys(store.water)) {
+    const ts = store.waterTimestamps[date] || 0;
+    if (ts < cutoff) {
+      delete store.water[date];
+      delete store.waterTimestamps[date];
+    }
+  }
+  const waterEntries = Object.entries(store.waterTimestamps).sort(
+    (a, b) => b[1] - a[1],
+  );
+  if (waterEntries.length > CACHE_MAX_ENTRIES) {
+    for (const [date] of waterEntries.slice(CACHE_MAX_ENTRIES)) {
+      delete store.water[date];
+      delete store.waterTimestamps[date];
+    }
+  }
+
   if (store.foodsTimestamp < cutoff) {
     store.foods = [];
     store.foodsTimestamp = 0;
@@ -76,6 +95,8 @@ export function loadStore(): OfflineStore {
     foodsTimestamp: raw?.foodsTimestamp ?? 0,
     weights: raw?.weights ?? {},
     weightTimestamps: raw?.weightTimestamps ?? {},
+    water: raw?.water ?? {},
+    waterTimestamps: raw?.waterTimestamps ?? {},
     queue: raw?.queue ?? [],
     nextId: raw?.nextId ?? -1,
   };
@@ -154,6 +175,18 @@ export function cacheWeight(date: string, weight: number) {
 export function getCachedWeight(date: string): number | undefined {
   const s = loadStore();
   return s.weights[date];
+}
+
+export function cacheWater(date: string, ml: number) {
+  const s = loadStore();
+  s.water[date] = ml;
+  s.waterTimestamps[date] = Date.now();
+  saveStore(s);
+}
+
+export function getCachedWater(date: string): number | undefined {
+  const s = loadStore();
+  return s.water[date];
 }
 
 export async function syncQueue() {
@@ -273,6 +306,19 @@ export async function syncQueue() {
         try {
           await api.put(`/weight/${item.payload.date}`, {
             weight: item.payload.weight,
+          });
+        } catch {
+          store.queue.unshift(item);
+          saveStore(store);
+          emitQueueSize();
+          return;
+        }
+        break;
+      }
+      case "setWater": {
+        try {
+          await api.put(`/water/${item.payload.date}`, {
+            milliliters: item.payload.milliliters,
           });
         } catch {
           store.queue.unshift(item);

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -28,6 +28,7 @@ interface AppState {
   favorites: SimpleFood[];
   presets: Preset[];
   weight: number | null;
+  water: number | null;
   goals: Goals;
   /** Information about the most recently deleted entry for undo. */
   lastDeleted: { mealId: number; entry: EntryType; index: number } | null;
@@ -61,6 +62,7 @@ interface AppActions {
   setAllMyFoods: (foods: SimpleFood[]) => void;
   toggleFavorite: (food: SimpleFood) => void;
   saveWeight: (w: number) => Promise<void>;
+  saveWater: (ml: number) => Promise<void>;
   setGoals: (g: Goals) => void;
   syncOffline: () => Promise<void>;
 }
@@ -176,6 +178,7 @@ export const useStore = create<AppState & AppActions>((set, get) => ({
   favorites: loadFavorites(),
   presets: [],
   weight: null,
+  water: null,
   goals: getGoalsForDate(initialDate),
   lastDeleted: null,
   redoDeleted: null,
@@ -313,6 +316,16 @@ export const useStore = create<AppState & AppActions>((set, get) => ({
     }
   },
 
+  saveWater: async (ml) => {
+    try {
+      await mealsApi.setWater(get().date, ml);
+      set({ water: ml });
+      toast.success("Water saved!");
+    } catch {
+      toast.error("Failed to save water.");
+    }
+  },
+
   fetchDay: async () => {
     try {
       let d = await mealsApi.getDayFull(get().date);
@@ -322,8 +335,15 @@ export const useStore = create<AppState & AppActions>((set, get) => ({
         }
         d = await mealsApi.getDayFull(get().date);
       }
-      const w = await mealsApi.getWeight(get().date);
-      set({ day: d, weight: w?.weight ?? null });
+      const [w, waterRes] = await Promise.all([
+        mealsApi.getWeight(get().date),
+        mealsApi.getWater(get().date),
+      ]);
+      set({
+        day: d,
+        weight: w?.weight ?? null,
+        water: waterRes?.milliliters ?? null,
+      });
       const mealExists = d.meals.some(
         (m: MealType) => m.name === get().mealName,
       );
@@ -587,8 +607,14 @@ export const useStore = create<AppState & AppActions>((set, get) => ({
     await get().fetchDay();
     const foods = await foodsApi.searchMyFoods();
     set({ allMyFoods: foods });
-    const w = await mealsApi.getWeight(get().date);
-    set({ weight: w?.weight ?? null });
+    const [w, waterRes] = await Promise.all([
+      mealsApi.getWeight(get().date),
+      mealsApi.getWater(get().date),
+    ]);
+    set({
+      weight: w?.weight ?? null,
+      water: waterRes?.milliliters ?? null,
+    });
   },
 }));
 

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -127,6 +127,7 @@ export type UpdateEntryPayload = { entryId: number; newGrams: number };
 export type MoveEntryPayload = { entryId: number; newOrder: number };
 export type DeleteEntryPayload = { entryId: number };
 export type SetWeightPayload = { date: string; weight: number };
+export type SetWaterPayload = { date: string; milliliters: number };
 
 export type OfflineOp =
   | { kind: "createMeal"; payload: CreateMealPayload }
@@ -136,7 +137,8 @@ export type OfflineOp =
   | { kind: "updateEntry"; payload: UpdateEntryPayload }
   | { kind: "moveEntry"; payload: MoveEntryPayload }
   | { kind: "deleteEntry"; payload: DeleteEntryPayload }
-  | { kind: "setWeight"; payload: SetWeightPayload };
+  | { kind: "setWeight"; payload: SetWeightPayload }
+  | { kind: "setWater"; payload: SetWaterPayload };
 
 export interface OfflineStore {
   days: Record<string, DayFull>;
@@ -145,6 +147,8 @@ export interface OfflineStore {
   foodsTimestamp: number;
   weights: Record<string, number>;
   weightTimestamps: Record<string, number>;
+  water: Record<string, number>;
+  waterTimestamps: Record<string, number>;
   queue: OfflineOp[];
   nextId: number;
 }


### PR DESCRIPTION
## Summary
- add water payload and store fields for offline caching
- implement getWater/setWater API with offline fallback
- track water in store with saveWater action and offline syncing

## Testing
- `pre-commit run --files web/src/api/meals.ts web/src/api/offline.ts web/src/store.ts web/src/types.ts`
- `cd web && npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4d396a64c832786acb7ffd5d5be0e