### PR TITLE
feat: track daily water intake offline

### DIFF
--- a/web/src/api/meals.ts
+++ b/web/src/api/meals.ts
@@ -14,6 +14,8 @@ import {
   cacheDay,
   cacheWeight,
   getCachedWeight,
+  cacheWater,
+  getCachedWater,
   nextTempId,
   enqueue,
 } from "./offline";
@@ -267,5 +269,30 @@ export async function setWeight(date: string, weight: number) {
     return { weight };
   }
   const response = await api.put(`/weight/${date}`, { weight });
+  return response.data;
+}
+
+export async function getWater(date: string) {
+  if (!isOnline()) {
+    const w = getCachedWater(date);
+    return w !== undefined ? { milliliters: w } : null;
+  }
+  try {
+    const response = await api.get(`/water/${date}`);
+    if (response.data?.milliliters !== undefined)
+      cacheWater(date, response.data.milliliters);
+    return response.data;
+  } catch {
+    return null;
+  }
+}
+
+export async function setWater(date: string, milliliters: number) {
+  if (!isOnline()) {
+    cacheWater(date, milliliters);
+    enqueue({ kind: "setWater", payload: { date, water: milliliters } });
+    return { milliliters };
+  }
+  const response = await api.put(`/water/${date}`, { milliliters });
   return response.data;
 }

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -28,6 +28,7 @@ interface AppState {
   favorites: SimpleFood[];
   presets: Preset[];
   weight: number | null;
+  water: number | null;
   goals: Goals;
   /** Information about the most recently deleted entry for undo. */
   lastDeleted: { mealId: number; entry: EntryType; index: number } | null;
@@ -61,6 +62,7 @@ interface AppActions {
   setAllMyFoods: (foods: SimpleFood[]) => void;
   toggleFavorite: (food: SimpleFood) => void;
   saveWeight: (w: number) => Promise<void>;
+  saveWater: (ml: number) => Promise<void>;
   setGoals: (g: Goals) => void;
   syncOffline: () => Promise<void>;
 }
@@ -176,6 +178,7 @@ export const useStore = create<AppState & AppActions>((set, get) => ({
   favorites: loadFavorites(),
   presets: [],
   weight: null,
+  water: null,
   goals: getGoalsForDate(initialDate),
   lastDeleted: null,
   redoDeleted: null,
@@ -313,6 +316,16 @@ export const useStore = create<AppState & AppActions>((set, get) => ({
     }
   },
 
+  saveWater: async (ml) => {
+    try {
+      await mealsApi.setWater(get().date, ml);
+      set({ water: ml });
+      toast.success("Water saved!");
+    } catch {
+      toast.error("Failed to save water.");
+    }
+  },
+
   fetchDay: async () => {
     try {
       let d = await mealsApi.getDayFull(get().date);
@@ -322,8 +335,15 @@ export const useStore = create<AppState & AppActions>((set, get) => ({
         }
         d = await mealsApi.getDayFull(get().date);
       }
-      const w = await mealsApi.getWeight(get().date);
-      set({ day: d, weight: w?.weight ?? null });
+      const [w, water] = await Promise.all([
+        mealsApi.getWeight(get().date),
+        mealsApi.getWater(get().date),
+      ]);
+      set({
+        day: d,
+        weight: w?.weight ?? null,
+        water: water?.milliliters ?? null,
+      });
       const mealExists = d.meals.some(
         (m: MealType) => m.name === get().mealName,
       );
@@ -587,8 +607,11 @@ export const useStore = create<AppState & AppActions>((set, get) => ({
     await get().fetchDay();
     const foods = await foodsApi.searchMyFoods();
     set({ allMyFoods: foods });
-    const w = await mealsApi.getWeight(get().date);
-    set({ weight: w?.weight ?? null });
+    const [w, water] = await Promise.all([
+      mealsApi.getWeight(get().date),
+      mealsApi.getWater(get().date),
+    ]);
+    set({ weight: w?.weight ?? null, water: water?.milliliters ?? null });
   },
 }));
 


### PR DESCRIPTION
## Summary
- support fetching and saving water intake with offline caching
- store and sync daily water intake along with weight

## Testing
- `npm test`
- `npm run lint` *(fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './config' is not defined by "exports" in eslint/package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d801f4588327bc249ceccfade78d