### PR TITLE
feat: add water tracker component

### DIFF
--- a/web/src/components/Summary.tsx
+++ b/web/src/components/Summary.tsx
@@ -3,6 +3,7 @@ import { useStore } from "../store";
 import RadialProgress from "./RadialProgress";
 import { Button } from "./ui/Button";
 import { Input } from "./ui/Input";
+import { WaterTracker } from "./WaterTracker";
 
 export function Summary() {
   const totals = useStore((state) => state.day?.totals);
@@ -111,6 +112,7 @@ export function Summary() {
               </Button>
             </div>
           </div>
+          <WaterTracker />
           <div className="text-xs text-text-muted mt-4 text-center">
             Calories for custom foods use the label; USDA items use 4/4/9.
           </div>

--- a/web/src/components/WaterTracker.tsx
+++ b/web/src/components/WaterTracker.tsx
@@ -1,0 +1,86 @@
+import { useState, useEffect } from "react";
+import { useStore } from "../store";
+import { Input } from "./ui/Input";
+import { Button } from "./ui/Button";
+
+const ML_PER_OUNCE = 29.5735;
+
+export function WaterTracker() {
+  const water = useStore((s) => s.water);
+  const saveWater = useStore((s) => s.saveWater);
+  const [ml, setMl] = useState("");
+  const [oz, setOz] = useState("");
+
+  useEffect(() => {
+    if (water != null) {
+      setMl(water.toString());
+      setOz((water / ML_PER_OUNCE).toFixed(1));
+    } else {
+      setMl("");
+      setOz("");
+    }
+  }, [water]);
+
+  const handleMlChange = (value: string) => {
+    setMl(value);
+    const num = parseFloat(value);
+    if (!isNaN(num)) {
+      setOz((num / ML_PER_OUNCE).toFixed(1));
+    } else {
+      setOz("");
+    }
+  };
+
+  const handleOzChange = (value: string) => {
+    setOz(value);
+    const num = parseFloat(value);
+    if (!isNaN(num)) {
+      setMl((num * ML_PER_OUNCE).toFixed(0));
+    } else {
+      setMl("");
+    }
+  };
+
+  const handleSave = () => {
+    const num = parseFloat(ml);
+    if (!isNaN(num)) {
+      saveWater(num);
+    }
+  };
+
+  return (
+    <div className="mt-6">
+      <label className="block mb-1 text-sm text-text dark:text-text-light">
+        Water
+      </label>
+      <div className="flex gap-2 mb-2">
+        <Input
+          id="water-ml"
+          type="number"
+          className="flex-1"
+          value={ml}
+          onChange={(e) => handleMlChange(e.target.value)}
+          placeholder="ml"
+        />
+        <Input
+          id="water-oz"
+          type="number"
+          className="flex-1"
+          value={oz}
+          onChange={(e) => handleOzChange(e.target.value)}
+          placeholder="oz"
+        />
+      </div>
+      <Button
+        className="btn-primary w-full"
+        aria-label="Save water"
+        onClick={handleSave}
+      >
+        Save
+      </Button>
+    </div>
+  );
+}
+
+export default WaterTracker;
+


### PR DESCRIPTION
## Summary
- add WaterTracker component for tracking water intake in ml or oz
- integrate water tracker into daily summary card

## Testing
- `npm --prefix web test`
- `npm --prefix web run lint` *(fails: Package subpath './config' is not defined by "exports" in eslint)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d960b0708327863280d261238c8c