### PR TITLE
feat: track daily water goals

### DIFF
--- a/web/src/components/Summary.tsx
+++ b/web/src/components/Summary.tsx
@@ -9,6 +9,7 @@ export function Summary() {
   const totals = useStore((state) => state.day?.totals);
   const weight = useStore((state) => state.weight);
   const goals = useStore((state) => state.goals);
+  const water = useStore((state) => state.water);
   const saveWeight = useStore((state) => state.saveWeight);
   const [input, setInput] = useState("");
 
@@ -71,22 +72,37 @@ export function Summary() {
               />
             </div>
 
-            {/* protein */}
-            <div className="flex-1 bg-brand-success/10 dark:bg-brand-success/30 p-3 rounded-lg text-center transition-shadow hover:shadow-md">
-              <div className="text-sm text-brand-success dark:text-brand-success mb-2">
-                Protein
-              </div>
-              <RadialProgress
-                value={totals?.protein ?? 0}
-                goal={goals.protein}
-                color="text-brand-success"
-                decimals={1}
-                unit="g"
-                valueClassName="text-base"
-              />
+          {/* protein */}
+          <div className="flex-1 bg-brand-success/10 dark:bg-brand-success/30 p-3 rounded-lg text-center transition-shadow hover:shadow-md">
+            <div className="text-sm text-brand-success dark:text-brand-success mb-2">
+              Protein
             </div>
+            <RadialProgress
+              value={totals?.protein ?? 0}
+              goal={goals.protein}
+              color="text-brand-success"
+              decimals={1}
+              unit="g"
+              valueClassName="text-base"
+            />
           </div>
-          <div className="mt-6">
+
+          {/* water */}
+          <div className="flex-1 bg-brand-primary/10 dark:bg-brand-primary/30 p-3 rounded-lg text-center transition-shadow hover:shadow-md">
+            <div className="text-sm text-brand-primary dark:text-brand-primary mb-2">
+              Water
+            </div>
+            <RadialProgress
+              value={water ?? 0}
+              goal={goals.water}
+              color="text-brand-primary"
+              decimals={0}
+              unit="ml"
+              valueClassName="text-base"
+            />
+          </div>
+        </div>
+        <div className="mt-6">
             <label
               htmlFor="body-weight"
               className="block mb-1 text-sm text-text dark:text-text-light"

--- a/web/src/components/control-panel/GoalsTab.tsx
+++ b/web/src/components/control-panel/GoalsTab.tsx
@@ -10,12 +10,14 @@ export function GoalsTab() {
     fat: string;
     carb: string;
     protein: string;
+    water: string;
     kcal?: string;
   };
   const [goalInput, setGoalInput] = useState<GoalInputState>({
     fat: "",
     carb: "",
     protein: "",
+    water: "",
   });
 
   useEffect(() => {
@@ -23,6 +25,7 @@ export function GoalsTab() {
       fat: goals.fat ? goals.fat.toString() : "",
       carb: goals.carb ? goals.carb.toString() : "",
       protein: goals.protein ? goals.protein.toString() : "",
+      water: goals.water ? goals.water.toString() : "",
     });
   }, [goals]);
 
@@ -31,6 +34,7 @@ export function GoalsTab() {
       fat: parseFloat(goalInput.fat) || 0,
       carb: parseFloat(goalInput.carb) || 0,
       protein: parseFloat(goalInput.protein) || 0,
+      water: parseFloat(goalInput.water) || 0,
       kcal: 0,
     };
     const computedKcal = g.protein * 4 + g.carb * 4 + g.fat * 9;
@@ -48,6 +52,7 @@ export function GoalsTab() {
     fat: "goal-fat",
     carb: "goal-carb",
     protein: "goal-protein",
+    water: "goal-water",
   } as const;
 
   return (
@@ -95,6 +100,21 @@ export function GoalsTab() {
             value={goalInput.protein}
             onChange={(e) =>
               setGoalInput({ ...goalInput, protein: e.target.value })
+            }
+          />
+        </div>
+        <div className="flex flex-col">
+          <label htmlFor={ids.water} className="sr-only">
+            Water ml
+          </label>
+          <Input
+            id={ids.water}
+            type="number"
+            step="1"
+            placeholder="Water ml"
+            value={goalInput.water}
+            onChange={(e) =>
+              setGoalInput({ ...goalInput, water: e.target.value })
             }
           />
         </div>

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -78,11 +78,13 @@ const getInitialTheme = (): Theme => {
 };
 
 // --- Daily Goals helpers -------------------------------------------------
-const EMPTY_GOALS: Goals = { kcal: 0, protein: 0, fat: 0, carb: 0 };
+const EMPTY_GOALS: Goals = { kcal: 0, protein: 0, fat: 0, carb: 0, water: 0 };
 
 // Return default goals saved in localStorage, or empty goals if none set
-const loadDefaultGoals = (): Goals =>
-  loadJSON<Goals>("defaultGoals", { ...EMPTY_GOALS });
+const loadDefaultGoals = (): Goals => ({
+  ...EMPTY_GOALS,
+  ...loadJSON<Partial<Goals>>("defaultGoals", {}),
+});
 
 // Return full mapping of date -> goals from localStorage
 const loadGoalsMap = (): Record<string, Goals> =>
@@ -91,12 +93,12 @@ const loadGoalsMap = (): Record<string, Goals> =>
 // Load goals for specific date, falling back to the most recently saved goals
 const getGoalsForDate = (d: string): Goals => {
   const all = loadGoalsMap();
-  if (all[d]) return all[d];
+  if (all[d]) return { ...EMPTY_GOALS, ...all[d] };
   const past = Object.keys(all)
     .filter((date) => date <= d)
     .sort();
   const latest = past[past.length - 1];
-  if (latest) return all[latest];
+  if (latest) return { ...EMPTY_GOALS, ...all[latest] };
   return loadDefaultGoals();
 };
 

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -91,6 +91,7 @@ export type Goals = {
   protein: number;
   fat: number;
   carb: number;
+  water: number;
 };
 
 export interface CustomFoodPayload {


### PR DESCRIPTION
## Summary
- track water target in goals and persist defaults
- allow editing water goal in the Goals tab
- show water consumption progress on the summary card

## Testing
- `cd web && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4ded0995c83278902687510633623