### PR TITLE
feat: add quick add buttons to water tracker

### DIFF
--- a/web/src/components/WaterTracker.tsx
+++ b/web/src/components/WaterTracker.tsx
@@ -8,6 +8,7 @@ const ML_PER_OUNCE = 29.5735;
 export function WaterTracker() {
   const water = useStore((s) => s.water);
   const saveWater = useStore((s) => s.saveWater);
+  const incrementWater = useStore((s) => s.incrementWater);
   const [ml, setMl] = useState("");
   const [oz, setOz] = useState("");
 
@@ -48,6 +49,14 @@ export function WaterTracker() {
     }
   };
 
+  const addWater = (amount: number) => {
+    const current = water ?? 0;
+    const total = current + amount;
+    setMl(total.toString());
+    setOz((total / ML_PER_OUNCE).toFixed(1));
+    incrementWater(amount);
+  };
+
   return (
     <div className="mt-6">
       <label className="block mb-1 text-sm text-text dark:text-text-light">
@@ -70,6 +79,22 @@ export function WaterTracker() {
           onChange={(e) => handleOzChange(e.target.value)}
           placeholder="oz"
         />
+      </div>
+      <div className="flex gap-2 mb-2">
+        <Button
+          type="button"
+          className="btn-secondary w-full"
+          onClick={() => addWater(250)}
+        >
+          +250 ml
+        </Button>
+        <Button
+          type="button"
+          className="btn-secondary w-full"
+          onClick={() => addWater(8 * ML_PER_OUNCE)}
+        >
+          +8 oz
+        </Button>
       </div>
       <Button
         className="btn-primary w-full"

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -63,6 +63,7 @@ interface AppActions {
   toggleFavorite: (food: SimpleFood) => void;
   saveWeight: (w: number) => Promise<void>;
   saveWater: (ml: number) => Promise<void>;
+  incrementWater: (amount: number) => Promise<void>;
   setGoals: (g: Goals) => void;
   syncOffline: () => Promise<void>;
 }
@@ -326,6 +327,11 @@ export const useStore = create<AppState & AppActions>((set, get) => ({
     } catch {
       toast.error("Failed to save water.");
     }
+  },
+
+  incrementWater: async (amount) => {
+    const current = get().water ?? 0;
+    await get().saveWater(current + amount);
   },
 
   fetchDay: async () => {


### PR DESCRIPTION
## Summary
- add +250ml and +8oz buttons to WaterTracker that persist water intake
- expose incrementWater action in store to update saved water by delta

## Testing
- `npm test`
- `npm run lint` *(fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED])*


------
https://chatgpt.com/codex/tasks/task_e_68a52304459c8327bff83892f49874f6