### PR TITLE
Include water intake in history and dashboard

### DIFF
--- a/server/tests/test_history.py
+++ b/server/tests/test_history.py
@@ -9,7 +9,7 @@ from sqlalchemy.pool import StaticPool
 from sqlmodel import Session, SQLModel, create_engine
 
 from server import app, db
-from server.models import BodyWeight, Food, FoodEntry, Meal
+from server.models import BodyWeight, Food, FoodEntry, Meal, WaterIntake
 
 
 def get_test_engine():
@@ -28,7 +28,7 @@ def override_get_session(engine):
     return _get_session
 
 
-def test_history_returns_macros_and_weight():
+def test_history_returns_macros_weight_and_water():
     engine = get_test_engine()
     db.engine = engine
     app.app.dependency_overrides[db.get_session] = override_get_session(engine)
@@ -55,6 +55,9 @@ def test_history_returns_macros_and_weight():
             w1 = BodyWeight(date=date(2024, 1, 1).isoformat(), weight=180)
             w2 = BodyWeight(date=date(2024, 1, 2).isoformat(), weight=181)
             session.add_all([w1, w2])
+            water1 = WaterIntake(date=date(2024, 1, 1).isoformat(), milliliters=1000)
+            water2 = WaterIntake(date=date(2024, 1, 2).isoformat(), milliliters=1500)
+            session.add_all([water1, water2])
             session.commit()
 
         resp = client.get(
@@ -74,6 +77,7 @@ def test_history_returns_macros_and_weight():
                 "carb": 5.0,
                 "fat": 2.0,
                 "weight": 180.0,
+                "water": 1000.0,
             },
             {
                 "date": "2024-01-02",
@@ -82,5 +86,6 @@ def test_history_returns_macros_and_weight():
                 "carb": 10.0,
                 "fat": 4.0,
                 "weight": 181.0,
+                "water": 1500.0,
             },
         ]

--- a/web/src/api/meals.ts
+++ b/web/src/api/meals.ts
@@ -244,7 +244,7 @@ export async function getHistory(
     end_date: endDate,
   };
   const response = await api.get("/history", { params });
-  return response.data;
+  return response.data.map((d: HistoryDay) => ({ ...d, water: d.water ?? 0 }));
 }
 
 export async function getWeight(date: string) {

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -28,6 +28,7 @@ const palettes = {
       fat: "#ffc658",
       carb: "#ff8042",
       weight: "#8884d8",
+      water: "#00bcd4",
     },
   },
   dark: {
@@ -41,6 +42,7 @@ const palettes = {
       fat: "#ffc658",
       carb: "#ff8042",
       weight: "#a5b4fc",
+      water: "#00bcd4",
     },
   },
 } as const;
@@ -86,9 +88,10 @@ export function DashboardPage() {
         acc.protein += curr.protein;
         acc.fat += curr.fat;
         acc.carb += curr.carb;
+        acc.water += curr.water ?? 0;
         return acc;
       },
-      { kcal: 0, protein: 0, fat: 0, carb: 0 },
+      { kcal: 0, protein: 0, fat: 0, carb: 0, water: 0 },
     );
 
     const count = data.length;
@@ -104,6 +107,7 @@ export function DashboardPage() {
       avgProtein: totals.protein / count,
       avgFat: totals.fat / count,
       avgCarb: totals.carb / count,
+      avgWater: totals.water / count,
       weightChange,
     };
   }, [data]);
@@ -126,7 +130,7 @@ export function DashboardPage() {
         ))}
       </div>
       {stats && (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-6 gap-4">
           <div className="card">
             <div className="card-body text-center">
               <div className="text-sm text-text-muted dark:text-text-light">
@@ -164,6 +168,16 @@ export function DashboardPage() {
               </div>
               <div className="text-2xl font-semibold dark:text-text-light">
                 {stats.avgCarb.toFixed(1)} g
+              </div>
+            </div>
+          </div>
+          <div className="card">
+            <div className="card-body text-center">
+              <div className="text-sm text-text-muted dark:text-text-light">
+                Avg Water
+              </div>
+              <div className="text-2xl font-semibold dark:text-text-light">
+                {stats.avgWater.toFixed(0)} ml
               </div>
             </div>
           </div>
@@ -313,6 +327,47 @@ export function DashboardPage() {
                   dataKey="weight"
                   name="Weight"
                   stroke={palette.lines.weight}
+                  strokeWidth={2}
+                  activeDot={{ r: 8 }}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          )}
+        </div>
+      </div>
+      <div className="card">
+        <div className="card-header">
+          <h2 className="font-semibold text-lg dark:text-text-light">
+            Water Intake Trend (Last {days} Days)
+          </h2>
+        </div>
+        <div className="card-body h-80">
+          {loading ? (
+            <LoadingSpinner />
+          ) : (
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={formattedData}>
+                <CartesianGrid strokeDasharray="3 3" stroke={palette.grid} />
+                <XAxis
+                  dataKey="date"
+                  tick={{ fill: palette.axis }}
+                  stroke={palette.axis}
+                />
+                <YAxis tick={{ fill: palette.axis }} stroke={palette.axis} />
+                <Tooltip
+                  contentStyle={{
+                    backgroundColor: palette.tooltipBg,
+                    border: "none",
+                  }}
+                  labelStyle={{ color: palette.tooltipColor }}
+                  itemStyle={{ color: palette.tooltipColor }}
+                />
+                <Legend wrapperStyle={{ color: palette.axis }} />
+                <Line
+                  type="monotone"
+                  dataKey="water"
+                  name="Water (ml)"
+                  stroke={palette.lines.water}
                   strokeWidth={2}
                   activeDot={{ r: 8 }}
                 />

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -82,7 +82,7 @@ export type HistoryDay = {
   fat: number;
   carb: number;
   weight?: number;
-  water?: number;
+  water: number;
 };
 
 // User-configurable daily macro goals


### PR DESCRIPTION
## Summary
- Aggregate and return daily water intake in history API
- Expose `water` field in client types and history fetcher
- Chart water intake and average water stats on dashboard

## Testing
- `pre-commit run --files server/routers/history.py server/tests/test_history.py web/src/api/meals.ts web/src/types.ts web/src/pages/DashboardPage.tsx`
- `pytest`
- `(cd web && npm test)`

------
https://chatgpt.com/codex/tasks/task_e_68a524314e4083278be0dca5c22d5fb8