### PR TITLE
feat: toggle water tracking visibility

### DIFF
--- a/web/src/components/Summary.tsx
+++ b/web/src/components/Summary.tsx
@@ -10,6 +10,8 @@ export function Summary() {
   const weight = useStore((state) => state.weight);
   const goals = useStore((state) => state.goals);
   const water = useStore((state) => state.water);
+  const showWater = useStore((state) => state.showWater);
+  const toggleShowWater = useStore((state) => state.toggleShowWater);
   const saveWeight = useStore((state) => state.saveWeight);
   const [input, setInput] = useState("");
 
@@ -20,10 +22,17 @@ export function Summary() {
   return (
     <div>
       <div className="sticky top-6 card">
-        <div className="card-header">
+        <div className="card-header flex items-center justify-between">
           <h2 className="font-semibold text-lg dark:text-text-light">
             Today's Totals
           </h2>
+          <Button
+            className="btn-ghost text-sm"
+            onClick={toggleShowWater}
+            aria-label="Toggle water tracking"
+          >
+            {showWater ? "Hide Water" : "Show Water"}
+          </Button>
         </div>
         <div className="card-body">
           <div className="flex justify-between items-stretch gap-2">
@@ -88,19 +97,21 @@ export function Summary() {
           </div>
 
           {/* water */}
-          <div className="flex-1 bg-brand-primary/10 dark:bg-brand-primary/30 p-3 rounded-lg text-center transition-shadow hover:shadow-md">
-            <div className="text-sm text-brand-primary dark:text-brand-primary mb-2">
-              Water
+          {showWater && (
+            <div className="flex-1 bg-brand-primary/10 dark:bg-brand-primary/30 p-3 rounded-lg text-center transition-shadow hover:shadow-md">
+              <div className="text-sm text-brand-primary dark:text-brand-primary mb-2">
+                Water
+              </div>
+              <RadialProgress
+                value={water ?? 0}
+                goal={goals.water}
+                color="text-brand-primary"
+                decimals={0}
+                unit="ml"
+                valueClassName="text-base"
+              />
             </div>
-            <RadialProgress
-              value={water ?? 0}
-              goal={goals.water}
-              color="text-brand-primary"
-              decimals={0}
-              unit="ml"
-              valueClassName="text-base"
-            />
-          </div>
+          )}
         </div>
         <div className="mt-6">
             <label
@@ -128,7 +139,7 @@ export function Summary() {
               </Button>
             </div>
           </div>
-          <WaterTracker />
+          {showWater && <WaterTracker />}
           <div className="text-xs text-text-muted mt-4 text-center">
             Calories for custom foods use the label; USDA items use 4/4/9.
           </div>

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -52,6 +52,7 @@ export function DashboardPage() {
   const [days, setDays] = useState(7);
   const [loading, setLoading] = useState(true);
   const theme = useStore((state) => state.theme);
+  const showWater = useStore((state) => state.showWater);
   const palette = palettes[theme];
 
   useEffect(() => {
@@ -171,16 +172,18 @@ export function DashboardPage() {
               </div>
             </div>
           </div>
-          <div className="card">
-            <div className="card-body text-center">
-              <div className="text-sm text-text-muted dark:text-text-light">
-                Avg Water
-              </div>
-              <div className="text-2xl font-semibold dark:text-text-light">
-                {stats.avgWater.toFixed(0)} ml
+          {showWater && (
+            <div className="card">
+              <div className="card-body text-center">
+                <div className="text-sm text-text-muted dark:text-text-light">
+                  Avg Water
+                </div>
+                <div className="text-2xl font-semibold dark:text-text-light">
+                  {stats.avgWater.toFixed(0)} ml
+                </div>
               </div>
             </div>
-          </div>
+          )}
           <div className="card">
             <div className="card-body text-center">
               <div className="text-sm text-text-muted dark:text-text-light">
@@ -335,47 +338,49 @@ export function DashboardPage() {
           )}
         </div>
       </div>
-      <div className="card">
-        <div className="card-header">
-          <h2 className="font-semibold text-lg dark:text-text-light">
-            Water Intake Trend (Last {days} Days)
-          </h2>
+      {showWater && (
+        <div className="card">
+          <div className="card-header">
+            <h2 className="font-semibold text-lg dark:text-text-light">
+              Water Intake Trend (Last {days} Days)
+            </h2>
+          </div>
+          <div className="card-body h-80">
+            {loading ? (
+              <LoadingSpinner />
+            ) : (
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={formattedData}>
+                  <CartesianGrid strokeDasharray="3 3" stroke={palette.grid} />
+                  <XAxis
+                    dataKey="date"
+                    tick={{ fill: palette.axis }}
+                    stroke={palette.axis}
+                  />
+                  <YAxis tick={{ fill: palette.axis }} stroke={palette.axis} />
+                  <Tooltip
+                    contentStyle={{
+                      backgroundColor: palette.tooltipBg,
+                      border: "none",
+                    }}
+                    labelStyle={{ color: palette.tooltipColor }}
+                    itemStyle={{ color: palette.tooltipColor }}
+                  />
+                  <Legend wrapperStyle={{ color: palette.axis }} />
+                  <Line
+                    type="monotone"
+                    dataKey="water"
+                    name="Water (ml)"
+                    stroke={palette.lines.water}
+                    strokeWidth={2}
+                    activeDot={{ r: 8 }}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            )}
+          </div>
         </div>
-        <div className="card-body h-80">
-          {loading ? (
-            <LoadingSpinner />
-          ) : (
-            <ResponsiveContainer width="100%" height="100%">
-              <LineChart data={formattedData}>
-                <CartesianGrid strokeDasharray="3 3" stroke={palette.grid} />
-                <XAxis
-                  dataKey="date"
-                  tick={{ fill: palette.axis }}
-                  stroke={palette.axis}
-                />
-                <YAxis tick={{ fill: palette.axis }} stroke={palette.axis} />
-                <Tooltip
-                  contentStyle={{
-                    backgroundColor: palette.tooltipBg,
-                    border: "none",
-                  }}
-                  labelStyle={{ color: palette.tooltipColor }}
-                  itemStyle={{ color: palette.tooltipColor }}
-                />
-                <Legend wrapperStyle={{ color: palette.axis }} />
-                <Line
-                  type="monotone"
-                  dataKey="water"
-                  name="Water (ml)"
-                  stroke={palette.lines.water}
-                  strokeWidth={2}
-                  activeDot={{ r: 8 }}
-                />
-              </LineChart>
-            </ResponsiveContainer>
-          )}
-        </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -30,6 +30,7 @@ interface AppState {
   weight: number | null;
   water: number | null;
   goals: Goals;
+  showWater: boolean;
   /** Information about the most recently deleted entry for undo. */
   lastDeleted: { mealId: number; entry: EntryType; index: number } | null;
   /** Information about the last undone deletion for redo. */
@@ -65,6 +66,7 @@ interface AppActions {
   saveWater: (ml: number) => Promise<void>;
   incrementWater: (amount: number) => Promise<void>;
   setGoals: (g: Goals) => void;
+  toggleShowWater: () => void;
   syncOffline: () => Promise<void>;
 }
 
@@ -183,6 +185,7 @@ export const useStore = create<AppState & AppActions>((set, get) => ({
   weight: null,
   water: null,
   goals: getGoalsForDate(initialDate),
+  showWater: loadJSON<boolean>("showWater", true),
   lastDeleted: null,
   redoDeleted: null,
 
@@ -608,6 +611,14 @@ export const useStore = create<AppState & AppActions>((set, get) => ({
       saveJSON("defaultGoals", g);
     }
     set({ goals: g });
+  },
+
+  toggleShowWater: () => {
+    set((state) => {
+      const value = !state.showWater;
+      saveJSON("showWater", value);
+      return { showWater: value };
+    });
   },
 
   syncOffline: async () => {


### PR DESCRIPTION
## Summary
- allow hiding water tracking with a toggle
- conditionally render water stats and chart across the app

## Testing
- `npm test`
- `npm run lint` *(fails: Package subpath './config' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a5261ce7cc832796af624e504bfcb4