### PR TITLE
Add environment variable examples and setup docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Example environment variables for the backend
+# Comma-separated list of allowed origins for CORS
+ALLOWED_ORIGINS=*
+
+# Token required to access configuration endpoints
+CONFIG_AUTH_TOKEN=secret-token

--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ npm run build && tauri build
 
 ## Environment Variables
 
+Copy the example files and adjust the values for your setup:
+
+```
+cp .env.example .env
+cp web/.env.example web/.env
+```
+
+The root `.env` configures backend variables such as `ALLOWED_ORIGINS` and
+`CONFIG_AUTH_TOKEN`. The `web/.env` file holds frontend variables like
+`VITE_API_BASE_URL` and `VITE_CONFIG_AUTH_TOKEN`.
+
 ### Frontend
 
 The frontend reads `VITE_API_BASE_URL` to know where to send API requests. If this

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,6 @@
+# Example environment variables for the frontend
+# Base URL of the API
+VITE_API_BASE_URL=http://localhost:8000
+
+# Token used by the frontend for configuration requests
+VITE_CONFIG_AUTH_TOKEN=secret-token


### PR DESCRIPTION
## Summary
- add backend `.env.example` with `ALLOWED_ORIGINS` and `CONFIG_AUTH_TOKEN`
- add frontend `web/.env.example` with `VITE_API_BASE_URL` and `VITE_CONFIG_AUTH_TOKEN`
- document copying example files to `.env`

## Testing
- `pre-commit run --all-files` *(fails: formatting issues in unrelated files)*
- `pre-commit run --files README.md .env.example web/.env.example`


------
https://chatgpt.com/codex/tasks/task_e_68a52ba90c708327b924613981be7ff7