### PR TITLE
chore: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node and Rust
+        uses: tauri-apps/setup-tauri@v1
+        with:
+          node-version: 18
+          rust-version: stable
+
+      - name: Install dependencies
+        working-directory: web
+        run: npm ci
+
+      - name: Build Tauri app
+        working-directory: web
+        run: |
+          npm run build
+          npx tauri build
+
+      - name: Upload installers
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.os }}-bundle
+          path: web/src-tauri/target/release/bundle/**

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ cd web
 npm run build && tauri build
 ```
 
+## Release Workflow
+
+The repository includes a GitHub Actions workflow (`.github/workflows/release.yml`) that builds installers for Windows, macOS, and Linux. Pushing a tag beginning with `v` or manually running the workflow triggers `tauri build` on each platform and uploads the generated bundles as workflow artifacts.
+
 ## Environment Variables
 
 Copy the example files and adjust the values for your setup:


### PR DESCRIPTION
## Summary
- build Tauri installers for Windows, macOS, and Linux via GitHub Actions
- upload bundled artifacts and document release workflow

## Testing
- `pre-commit run --files README.md .github/workflows/release.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a52d37a3688327af26636405a12102