### PR TITLE
Add busy state with global loading overlay

### DIFF
--- a/web/src/components/BusyOverlay.tsx
+++ b/web/src/components/BusyOverlay.tsx
@@ -1,0 +1,12 @@
+import { LoadingSpinner } from "./LoadingSpinner";
+import { useStore } from "../store";
+
+export function BusyOverlay() {
+  const busy = useStore((state) => state.busy);
+  if (!busy) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <LoadingSpinner />
+    </div>
+  );
+}

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -13,6 +13,7 @@ import { format, subDays, parseISO } from "date-fns";
 import { getHistory } from "../api/meals";
 import type { HistoryDay } from "../types";
 import { LoadingSpinner } from "../components/LoadingSpinner";
+import { BusyOverlay } from "../components/BusyOverlay";
 import { useStore } from "../store";
 import { Button } from "../components/ui/Button";
 
@@ -115,6 +116,7 @@ export function DashboardPage() {
 
   return (
     <div className="space-y-8">
+      <BusyOverlay />
       <div className="flex gap-2">
         {[7, 30, 90].map((opt) => (
           <Button

--- a/web/src/pages/TrackerPage.tsx
+++ b/web/src/pages/TrackerPage.tsx
@@ -2,10 +2,12 @@ import { ControlPanel } from "../components/control-panel/ControlPanel";
 import { DailyLog } from "../components/DailyLog";
 import { Summary } from "../components/Summary";
 import { QuickAdd } from "../components/QuickAdd";
+import { BusyOverlay } from "../components/BusyOverlay";
 
 export function TrackerPage() {
   return (
     <div className="space-y-4">
+      <BusyOverlay />
       <QuickAdd />
       <div className="grid grid-cols-1 lg:grid-cols-[1fr_3fr_1fr] gap-8">
         <ControlPanel />


### PR DESCRIPTION
## Summary
- track ongoing async actions with a `busy` flag in the store
- show a full screen LoadingSpinner overlay when the app is busy

## Testing
- `npm run lint` *(fails: Package subpath './config' is not defined in eslint exports)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a52e8c512883279f4c239292c9fb0b