### PR TITLE
Fix unclosed store object

### DIFF
--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -677,6 +677,7 @@ export const useStore = create<AppState & AppActions>((set, get) => {
       set({ weight: w?.weight ?? null, water: water?.milliliters ?? null });
     });
   },
+};
 });
 
 if (typeof window !== "undefined") {


### PR DESCRIPTION
## Summary
- Correct unclosed return object in `web/src/store.ts` that caused build failure

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find name 'global'; 'meal' is possibly 'undefined')*


------
https://chatgpt.com/codex/tasks/task_e_68a5308672ec8327865778db483397dc